### PR TITLE
Potential fix for code scanning alert no. 13: Server-side request forgery

### DIFF
--- a/server/services/integrations/GithubService.js
+++ b/server/services/integrations/GithubService.js
@@ -82,6 +82,12 @@ class GithubService {
   }
 
   async validateAndSaveRepo(uid, repoName) {
+    // Validate the repository name format
+    const repoNamePattern = /^[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+$/;
+    if (!repoNamePattern.test(repoName)) {
+      throw new Error('Invalid repository name format');
+    }
+
     const organizationData = await FirestoreService.getDocument(
       'organizations',
       uid


### PR DESCRIPTION
Potential fix for [https://github.com/kartikmehta8/thedaotool/security/code-scanning/13](https://github.com/kartikmehta8/thedaotool/security/code-scanning/13)

To fix the issue, we need to validate and sanitize the `repoName` parameter before using it in the `axios.get` call. Specifically:
1. Ensure that `repoName` matches a valid GitHub repository name format. GitHub repository names typically consist of alphanumeric characters, hyphens, and underscores.
2. Reject or sanitize any input that does not conform to this format.
3. Implement the validation logic in `validateAndSaveRepo` in `GithubService.js` to ensure that the `repoName` is safe to use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
