### PR TITLE
Restrict actions for unverified accounts

### DIFF
--- a/client/src/components/EmailVerificationBanner.js
+++ b/client/src/components/EmailVerificationBanner.js
@@ -1,32 +1,16 @@
-import React, { useState } from 'react';
-import { Alert, Button } from 'antd';
-import { sendEmailVerification } from '../api/auth';
-import toast from '../utils/toast';
+import React from 'react';
+import { Alert } from 'antd';
 
 const EmailVerificationBanner = ({ email }) => {
-  const [loading, setLoading] = useState(false);
-
-  const handleResend = async () => {
-    try {
-      setLoading(true);
-      await sendEmailVerification(email);
-      toast.success('Verification email sent');
-    } catch (err) {
-      toast.error(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <Alert
-      message="Email not verified"
       type="warning"
       showIcon
       description={
-        <Button size="small" onClick={handleResend} loading={loading}>
-          Resend link
-        </Button>
+        <>
+          Please verify your email address <strong>{email}</strong> to access
+          all features.
+        </>
       }
       style={{ marginBottom: '1rem' }}
     />

--- a/client/src/components/EmailVerificationBanner.js
+++ b/client/src/components/EmailVerificationBanner.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { Alert, Button } from 'antd';
+import { sendEmailVerification } from '../api/auth';
+import toast from '../utils/toast';
+
+const EmailVerificationBanner = ({ email }) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleResend = async () => {
+    try {
+      setLoading(true);
+      await sendEmailVerification(email);
+      toast.success('Verification email sent');
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Alert
+      message="Email not verified"
+      type="warning"
+      showIcon
+      description={
+        <Button size="small" onClick={handleResend} loading={loading}>
+          Resend link
+        </Button>
+      }
+      style={{ marginBottom: '1rem' }}
+    />
+  );
+};
+
+export default EmailVerificationBanner;

--- a/client/src/components/contributor/BountyCard.js
+++ b/client/src/components/contributor/BountyCard.js
@@ -20,7 +20,13 @@ const BountyCard = ({
   onOpenSubmitModal,
   onOpenChat,
 }) => {
+  const emailVerified =
+    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
   const handleApplyToBounty = async () => {
+    if (!emailVerified) {
+      toast.warning('Please verify your email before applying');
+      return;
+    }
     try {
       await applyToBounty(bounty.id, userId);
       onRefetch();

--- a/client/src/components/contributor/SubmitWorkModal.js
+++ b/client/src/components/contributor/SubmitWorkModal.js
@@ -5,8 +5,14 @@ import toast from '../../utils/toast';
 
 const SubmitWorkModal = ({ visible, bountyId, onCancel, onSubmitSuccess }) => {
   const [submission, setSubmission] = useState('');
+  const emailVerified =
+    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
 
   const handleSubmitWork = async () => {
+    if (!emailVerified) {
+      toast.warning('Please verify your email before submitting work');
+      return;
+    }
     try {
       await submitWork(bountyId, submission);
       onSubmitSuccess();

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,3 +1,4 @@
 import Navbar from './Navbar';
+import EmailVerificationBanner from './EmailVerificationBanner';
 
-export { Navbar };
+export { Navbar, EmailVerificationBanner };

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -5,8 +5,14 @@ import toast from '../../utils/toast';
 
 const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
   const [form] = Form.useForm();
+  const emailVerified =
+    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
 
   const handleCreate = async () => {
+    if (!emailVerified) {
+      toast.warning('Please verify your email before creating a bounty');
+      return;
+    }
     try {
       const values = await form.validateFields();
       await createBounty(values, userId);

--- a/client/src/pages/contributor/ContributorDashboard.js
+++ b/client/src/pages/contributor/ContributorDashboard.js
@@ -8,6 +8,7 @@ import {
   SubmitWorkModal,
   ChatModal,
 } from '../../components/contributor';
+import EmailVerificationBanner from '../../components/EmailVerificationBanner';
 
 const { Title } = Typography;
 
@@ -21,6 +22,7 @@ const ContributorDashboard = () => {
 
   const user = JSON.parse(localStorage.getItem('payman-user')) || {};
   const uid = user.uid;
+  const emailVerified = user.emailVerified;
 
   const loadBountys = async () => {
     const bountysData = await fetchBountysForContributor(uid);
@@ -55,6 +57,7 @@ const ContributorDashboard = () => {
       <Title level={3} style={{ color: '#fff' }}>
         Available Bounties
       </Title>
+      {!emailVerified && <EmailVerificationBanner email={user.email} />}
 
       <div style={{ marginBottom: '1rem' }}>
         <span style={{ color: '#fff', marginRight: '0.5rem' }}>

--- a/client/src/pages/organization/OrganizationDashboard.js
+++ b/client/src/pages/organization/OrganizationDashboard.js
@@ -9,6 +9,8 @@ import {
   CreateBountyModal,
   ViewBountyModal,
 } from '../../components/organization';
+import EmailVerificationBanner from '../../components/EmailVerificationBanner';
+import toast from '../../utils/toast';
 
 const { Title } = Typography;
 
@@ -22,6 +24,7 @@ const OrganizationDashboard = () => {
 
   const user = JSON.parse(localStorage.getItem('payman-user')) || {};
   const uid = user.uid;
+  const emailVerified = user.emailVerified;
 
   const fetchBountys = async () => {
     const fetchedBountys = await getBountysForOrganization(uid);
@@ -43,9 +46,16 @@ const OrganizationDashboard = () => {
       <Title level={3} style={{ color: '#fff' }}>
         My Bounties
       </Title>
+      {!emailVerified && <EmailVerificationBanner email={user.email} />}
       <Button
         icon={<PlusOutlined />}
-        onClick={() => setModalVisible(true)}
+        onClick={() => {
+          if (!emailVerified) {
+            toast.warning('Please verify your email before creating a bounty');
+            return;
+          }
+          setModalVisible(true);
+        }}
         type="primary"
         style={{ marginBottom: 16 }}
       >

--- a/server/middlewares/implementations/EmailVerifiedMiddleware.js
+++ b/server/middlewares/implementations/EmailVerifiedMiddleware.js
@@ -1,0 +1,20 @@
+const UserService = require('../../services/user/UserService');
+const ResponseHelper = require('../../utils/ResponseHelper');
+
+class EmailVerifiedMiddleware {
+  static async requireVerified(req, res, next) {
+    try {
+      const user = await UserService.getUserData(req.user.uid);
+      if (!user.emailVerified) {
+        return ResponseHelper.forbidden(res, 'Email not verified');
+      }
+      next();
+    } catch (err) {
+      return ResponseHelper.error(res, 'Failed to verify email');
+    }
+  }
+
+  apply(app) {}
+}
+
+module.exports = EmailVerifiedMiddleware;

--- a/server/routes/implementations/ContributorRoutes.js
+++ b/server/routes/implementations/ContributorRoutes.js
@@ -3,6 +3,7 @@ const ContributorController = require('../../controllers/contributorController')
 const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
 const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
 const contributorValidator = require('../../validators/contributorValidators');
+const EmailVerifiedMiddleware = require('../../middlewares/implementations/EmailVerifiedMiddleware');
 const IRoute = require('../IRoute');
 
 class ContributorRoutes extends IRoute {
@@ -13,12 +14,14 @@ class ContributorRoutes extends IRoute {
 
     router.post(
       '/apply',
+      EmailVerifiedMiddleware.requireVerified,
       ValidationMiddleware.use(contributorValidator.applyToBountySchema),
       ContributorController.applyToBounty
     );
 
     router.post(
       '/submit',
+      EmailVerifiedMiddleware.requireVerified,
       ValidationMiddleware.use(contributorValidator.submitWorkSchema),
       ContributorController.submitWork
     );

--- a/server/routes/implementations/OrganizationRoutes.js
+++ b/server/routes/implementations/OrganizationRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const OrganizationController = require('../../controllers/organizationController');
 const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
+const EmailVerifiedMiddleware = require('../../middlewares/implementations/EmailVerifiedMiddleware');
 const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
 const organizationValidator = require('../../validators/organizationValidators');
 const IRoute = require('../IRoute');
@@ -13,6 +14,7 @@ class OrganizationRoutes extends IRoute {
 
     router.post(
       '/bounty',
+      EmailVerifiedMiddleware.requireVerified,
       ValidationMiddleware.use(organizationValidator.createBountySchema),
       OrganizationController.createBounty
     );


### PR DESCRIPTION
## Summary
- require email verification in contributor and organization routes
- block creation and submission actions on the client
- show a banner to resend verification link on dashboards

## Testing
- `npm run format:check` in `client`
- `npm run format:check` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68409727fad08326810df3ef5389dbc1