### PR TITLE
Optimize frontend API calls

### DIFF
--- a/client/src/components/organization/DiscordIntegration.js
+++ b/client/src/components/organization/DiscordIntegration.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Button, Typography, Switch, Select, Space } from 'antd';
 import {
   disconnectDiscord,
-  fetchDiscordProfile,
   updateDiscordSettings,
   fetchDiscordChannels,
   saveDiscordChannel,
@@ -13,22 +12,8 @@ import toast from '../../utils/toast';
 const { Paragraph, Text } = Typography;
 const { Option } = Select;
 
-const DiscordIntegration = ({ user }) => {
-  const [profile, setProfile] = useState({});
+const DiscordIntegration = ({ uid, profile, setProfile }) => {
   const [channels, setChannels] = useState([]);
-  const uid = user.uid;
-
-  useEffect(() => {
-    const loadProfile = async () => {
-      try {
-        const data = await fetchDiscordProfile(uid);
-        setProfile(data || {});
-      } catch (err) {
-        // TODO: handle error gracefully.
-      }
-    };
-    loadProfile();
-  }, [uid]);
 
   useEffect(() => {
     const loadChannels = async () => {

--- a/client/src/components/organization/GitHubIntegration.js
+++ b/client/src/components/organization/GitHubIntegration.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Button, Typography, Space, Select, Spin } from 'antd';
-import { getOrganizationProfile } from '../../api/organization/profile';
 import {
   disconnectGitHub,
   fetchGitHubRepos,
@@ -12,30 +11,22 @@ import toast from '../../utils/toast';
 const { Paragraph, Text } = Typography;
 const { Option } = Select;
 
-const GitHubIntegration = ({ user }) => {
-  const [profile, setProfile] = useState({});
+const GitHubIntegration = ({ uid, profile, setProfile }) => {
   const [repos, setRepos] = useState([]);
-  const [loading, setLoading] = useState(true);
   const [selectingRepo, setSelectingRepo] = useState(false);
-
-  const uid = user.uid;
-
   useEffect(() => {
-    const load = async () => {
-      const data = await getOrganizationProfile(uid);
-      setProfile(data || {});
-      setLoading(false);
-
-      if (data?.githubToken) {
+    const loadRepos = async () => {
+      if (profile?.githubToken) {
         setSelectingRepo(true);
         const repoList = await fetchGitHubRepos(uid);
         setRepos(repoList);
         setSelectingRepo(false);
+      } else {
+        setRepos([]);
       }
     };
-
-    load();
-  }, [uid]);
+    loadRepos();
+  }, [profile?.githubToken, uid]);
 
   const handleOAuth = async () => {
     const redirectUrl = await handleAuth(uid);
@@ -57,8 +48,6 @@ const GitHubIntegration = ({ user }) => {
     setRepos([]);
     setProfile((prev) => ({ ...prev, githubToken: '', repo: '' }));
   };
-
-  if (loading) return <Spin />;
 
   return (
     <>

--- a/client/src/pages/contributor/ContributorDashboard.js
+++ b/client/src/pages/contributor/ContributorDashboard.js
@@ -27,7 +27,9 @@ const ContributorDashboard = () => {
   const loadBountys = async () => {
     const bountysData = await fetchBountysForContributor(uid);
     setBountys(bountysData);
+  };
 
+  const loadSkills = async () => {
     const profile = await getContributorProfile(uid);
     if (profile?.skills) {
       const formattedSkills = profile.skills
@@ -39,6 +41,7 @@ const ContributorDashboard = () => {
 
   useEffect(() => {
     loadBountys();
+    loadSkills();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -190,7 +190,11 @@ const OrganizationProfile = () => {
           style={{ width: 500, backgroundColor: '#1f1f1f', marginBottom: 20 }}
           loading={loading}
         >
-          <GitHubIntegration user={user} />
+          <GitHubIntegration
+            uid={uid}
+            profile={profile}
+            setProfile={setProfile}
+          />
         </Card>
         <Card
           className="form-card"
@@ -198,7 +202,11 @@ const OrganizationProfile = () => {
           loading={loading}
           bodyStyle={{ padding: '1rem' }}
         >
-          <DiscordIntegration user={user} />
+          <DiscordIntegration
+            uid={uid}
+            profile={profile}
+            setProfile={setProfile}
+          />
         </Card>
       </Content>
     </Layout>


### PR DESCRIPTION
## Summary
- refactor GitHub and Discord integration components to use parent profile
- avoid refetching contributor profile when reloading bounties
- pass profile state to integration components in organization profile page

## Testing
- `npm run format`
- `npm run format` in server

------
https://chatgpt.com/codex/tasks/task_e_68409e591d8c8326b919246ca3fa7b0d