### PR TITLE
[Feature] Refactor middlewares and Add OTP cleanup CRON

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,5 +1,5 @@
-const UserService = require('../services/user/UserService');
-const ResponseHelper = require('../utils/ResponseHelper');
+const UserService = require('@services/user/UserService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class AuthController {
   async loginUser(req, res) {

--- a/server/controllers/contributorController.js
+++ b/server/controllers/contributorController.js
@@ -1,5 +1,5 @@
-const ContributorService = require('../services/user/ContributorService');
-const ResponseHelper = require('../utils/ResponseHelper');
+const ContributorService = require('@services/user/ContributorService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class ContributorController {
   async applyToBounty(req, res) {

--- a/server/controllers/discordController.js
+++ b/server/controllers/discordController.js
@@ -1,5 +1,5 @@
-const DiscordService = require('../services/integrations/DiscordService');
-const ResponseHelper = require('../utils/ResponseHelper');
+const DiscordService = require('@services/integrations/DiscordService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class DiscordController {
   initiateOAuth(req, res) {

--- a/server/controllers/githubController.js
+++ b/server/controllers/githubController.js
@@ -1,5 +1,5 @@
-const GithubService = require('../services/integrations/GithubService');
-const ResponseHelper = require('../utils/ResponseHelper');
+const GithubService = require('@services/integrations/GithubService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class GithubController {
   async initiateOAuth(req, res) {

--- a/server/controllers/organizationController.js
+++ b/server/controllers/organizationController.js
@@ -1,5 +1,5 @@
-const OrganizationService = require('../services/user/OrganizationService');
-const ResponseHelper = require('../utils/ResponseHelper');
+const OrganizationService = require('@services/user/OrganizationService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class OrganizationController {
   async createBounty(req, res) {

--- a/server/controllers/paymanController.js
+++ b/server/controllers/paymanController.js
@@ -1,6 +1,6 @@
-const PaymanService = require('../services/integrations/PaymanService');
-const ResponseHelper = require('../utils/ResponseHelper');
-const FirestoreService = require('../services/database/FirestoreService');
+const PaymanService = require('@services/integrations/PaymanService');
+const ResponseHelper = require('@utils/ResponseHelper');
+const FirestoreService = require('@services/database/FirestoreService');
 
 class PaymanController {
   async getApiKey(req, res) {

--- a/server/cron/functions/syncGitHubIssues.js
+++ b/server/cron/functions/syncGitHubIssues.js
@@ -1,6 +1,6 @@
-const FirestoreService = require('../../services/database/FirestoreService');
-const GithubService = require('../../services/integrations/GithubService');
-const postToDiscord = require('../../utils/postToDiscord');
+const FirestoreService = require('@services/database/FirestoreService');
+const GithubService = require('@services/integrations/GithubService');
+const postToDiscord = require('@utils/postToDiscord');
 
 async function syncGitHubIssues() {
   try {

--- a/server/cron/implementations/GitHubSyncJob.js
+++ b/server/cron/implementations/GitHubSyncJob.js
@@ -1,6 +1,6 @@
 const cron = require('node-cron');
-const syncGitHubIssues = require('../functions/syncGitHubIssues');
-const ICronJob = require('../ICronJob');
+const syncGitHubIssues = require('@cron/functions/syncGitHubIssues');
+const ICronJob = require('@cron/ICronJob');
 
 class GitHubSyncJob extends ICronJob {
   schedule() {

--- a/server/cron/implementations/LoginAttemptCleanupJob.js
+++ b/server/cron/implementations/LoginAttemptCleanupJob.js
@@ -1,6 +1,6 @@
 const cron = require('node-cron');
-const ICronJob = require('../ICronJob');
-const RealtimeDatabaseService = require('../../services/database/RealtimeDatabaseService');
+const ICronJob = require('@cron/ICronJob');
+const RealtimeDatabaseService = require('@services/database/RealtimeDatabaseService');
 
 class LoginAttemptCleanupJob extends ICronJob {
   schedule() {

--- a/server/cron/implementations/OTPTokenCleanupJob.js
+++ b/server/cron/implementations/OTPTokenCleanupJob.js
@@ -1,0 +1,14 @@
+const cron = require('node-cron');
+const ICronJob = require('@cron/ICronJob');
+const OTPTokenService = require('@services/misc/OTPTokenService');
+
+class OTPTokenCleanupJob extends ICronJob {
+  schedule() {
+    // Schedule: every 10 minutes
+    cron.schedule('0 */10 * * * *', async () => {
+      await OTPTokenService.clearExpiredOTPs();
+    });
+  }
+}
+
+module.exports = OTPTokenCleanupJob;

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+require('module-alias/register');
 const express = require('express');
 const http = require('http');
 
@@ -6,10 +7,10 @@ const app = express();
 const server = http.createServer(app);
 const initSocket = require('./sockets/chat');
 
-const MiddlewareManager = require('./middlewares/MiddlewareManager');
-const RouteManager = require('./routes/RouteManager');
-const CronManager = require('./cron/CronManager');
-const ErrorHandlerMiddleware = require('./middlewares/implementations/ErrorHandlerMiddleware');
+const MiddlewareManager = require('@middlewares/MiddlewareManager');
+const RouteManager = require('@routes/RouteManager');
+const CronManager = require('@cron/CronManager');
+const ErrorHandlerMiddleware = require('@middlewares/implementations/core/ErrorHandlerMiddleware');
 
 const middlewareManager = new MiddlewareManager();
 middlewareManager.applyMiddlewares(app);

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,6 @@ middlewareManager.applyMiddlewares(app);
 const routeManager = new RouteManager();
 routeManager.applyRoutes(app);
 
-// Apply centralized error handler after all routes
 new ErrorHandlerMiddleware().apply(app);
 
 const cronManager = new CronManager();

--- a/server/middlewares/MiddlewareManager.js
+++ b/server/middlewares/MiddlewareManager.js
@@ -7,17 +7,29 @@ class MiddlewareManager {
   }
 
   loadMiddlewares() {
-    const middlewares = [];
     const implementationsPath = path.join(__dirname, 'implementations');
-    const files = fs.readdirSync(implementationsPath);
+    const files = this.getFilesRecursively(implementationsPath);
 
-    files.forEach((file) => {
-      const MiddlewareClass = require(path.join(implementationsPath, file));
-      const instance = new MiddlewareClass();
-      middlewares.push(instance);
+    return files.map((file) => {
+      const MiddlewareClass = require(file);
+      return new MiddlewareClass();
     });
+  }
 
-    return middlewares;
+  getFilesRecursively(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    let files = [];
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files = files.concat(this.getFilesRecursively(fullPath));
+      } else if (entry.isFile() && fullPath.endsWith('.js')) {
+        files.push(fullPath);
+      }
+    }
+
+    return files;
   }
 
   applyMiddlewares(app) {

--- a/server/middlewares/implementations/auth/AuthMiddleware.js
+++ b/server/middlewares/implementations/auth/AuthMiddleware.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const ResponseHelper = require('../../utils/ResponseHelper');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class AuthMiddleware {
   static authenticate(allowedRoles = []) {

--- a/server/middlewares/implementations/auth/EmailVerifiedMiddleware.js
+++ b/server/middlewares/implementations/auth/EmailVerifiedMiddleware.js
@@ -1,5 +1,5 @@
-const UserService = require('../../services/user/UserService');
-const ResponseHelper = require('../../utils/ResponseHelper');
+const UserService = require('@services/user/UserService');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class EmailVerifiedMiddleware {
   static async requireVerified(req, res, next) {

--- a/server/middlewares/implementations/core/BodyParserMiddleware.js
+++ b/server/middlewares/implementations/core/BodyParserMiddleware.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class BodyParserMiddleware extends IMiddleware {
   apply(app) {

--- a/server/middlewares/implementations/core/CompressionMiddleware.js
+++ b/server/middlewares/implementations/core/CompressionMiddleware.js
@@ -1,5 +1,5 @@
 const compression = require('compression');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class CompressionMiddleware extends IMiddleware {
   constructor() {

--- a/server/middlewares/implementations/core/ErrorHandlerMiddleware.js
+++ b/server/middlewares/implementations/core/ErrorHandlerMiddleware.js
@@ -1,5 +1,5 @@
-const IMiddleware = require('../IMiddleware');
-const ResponseHelper = require('../../utils/ResponseHelper');
+const IMiddleware = require('@middlewares/IMiddleware');
+const ResponseHelper = require('@utils/ResponseHelper');
 
 class ErrorHandlerMiddleware extends IMiddleware {
   apply(app) {

--- a/server/middlewares/implementations/core/MorganMiddleware.js
+++ b/server/middlewares/implementations/core/MorganMiddleware.js
@@ -1,5 +1,5 @@
 const morgan = require('morgan');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class MorganMiddleware extends IMiddleware {
   constructor() {

--- a/server/middlewares/implementations/security/ContentTypeValidatorMiddleware.js
+++ b/server/middlewares/implementations/security/ContentTypeValidatorMiddleware.js
@@ -1,4 +1,4 @@
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class ContentTypeValidatorMiddleware extends IMiddleware {
   apply(app) {

--- a/server/middlewares/implementations/security/CorsMiddleware.js
+++ b/server/middlewares/implementations/security/CorsMiddleware.js
@@ -1,5 +1,5 @@
 const cors = require('cors');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 require('dotenv').config();
 
 class CorsMiddleware extends IMiddleware {

--- a/server/middlewares/implementations/security/HelmetMiddleware.js
+++ b/server/middlewares/implementations/security/HelmetMiddleware.js
@@ -1,5 +1,5 @@
 const helmet = require('helmet');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class HelmetMiddleware extends IMiddleware {
   constructor() {

--- a/server/middlewares/implementations/security/RateLimitMiddleware.js
+++ b/server/middlewares/implementations/security/RateLimitMiddleware.js
@@ -1,5 +1,5 @@
 const rateLimit = require('express-rate-limit');
-const IMiddleware = require('../IMiddleware');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class RateLimitMiddleware extends IMiddleware {
   constructor() {

--- a/server/middlewares/implementations/validation/ValidationMiddleware.js
+++ b/server/middlewares/implementations/validation/ValidationMiddleware.js
@@ -1,5 +1,5 @@
-const ResponseHelper = require('../../utils/ResponseHelper');
-const IMiddleware = require('../IMiddleware');
+const ResponseHelper = require('@utils/ResponseHelper');
+const IMiddleware = require('@middlewares/IMiddleware');
 
 class ValidationMiddleware extends IMiddleware {
   apply(app) {}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,10 +11,8 @@
       "dependencies": {
         "axios": "^1.8.4",
         "bcryptjs": "^3.0.2",
-        "body-parser": "^2.2.0",
         "compression": "^1.8.0",
         "cors": "^2.8.5",
-        "crypto": "^1.0.1",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
@@ -22,6 +20,7 @@
         "helmet": "^8.1.0",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
+        "module-alias": "^2.2.2",
         "morgan": "^1.10.0",
         "node-cron": "^3.0.3",
         "nodemailer": "^6.10.0",
@@ -588,7 +587,7 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.4",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -884,10 +883,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "license": "ISC"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -1988,6 +1983,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+      "license": "MIT"
     },
     "node_modules/morgan": {
       "version": "1.10.0",

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,16 @@
     "node-cron": "^3.0.3",
     "nodemailer": "^6.10.0",
     "paymanai": "^2.7.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "module-alias": "^2.2.2"
+  },
+  "_moduleAliases": {
+    "@controllers": "./controllers",
+    "@middlewares": "./middlewares",
+    "@routes": "./routes",
+    "@services": "./services",
+    "@utils": "./utils",
+    "@validators": "./validators",
+    "@cron": "./cron"
   }
 }

--- a/server/routes/implementations/AuthRoutes.js
+++ b/server/routes/implementations/AuthRoutes.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const AuthController = require('../../controllers/authController');
-const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
-const authValidator = require('../../validators/authValidators');
-const catchAsync = require('../../utils/catchAsync');
+const AuthController = require('@controllers/authController');
+const ValidationMiddleware = require('@middlewares/implementations/validation/ValidationMiddleware');
+const authValidator = require('@validators/authValidators');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class AuthRoutes extends IRoute {

--- a/server/routes/implementations/ContributorRoutes.js
+++ b/server/routes/implementations/ContributorRoutes.js
@@ -1,10 +1,10 @@
 const express = require('express');
-const ContributorController = require('../../controllers/contributorController');
-const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
-const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
-const contributorValidator = require('../../validators/contributorValidators');
-const EmailVerifiedMiddleware = require('../../middlewares/implementations/EmailVerifiedMiddleware');
-const catchAsync = require('../../utils/catchAsync');
+const ContributorController = require('@controllers/contributorController');
+const AuthMiddleware = require('@middlewares/implementations/auth/AuthMiddleware');
+const ValidationMiddleware = require('@middlewares/implementations/validation/ValidationMiddleware');
+const contributorValidator = require('@validators/contributorValidators');
+const EmailVerifiedMiddleware = require('@middlewares/implementations/auth/EmailVerifiedMiddleware');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class ContributorRoutes extends IRoute {

--- a/server/routes/implementations/DiscordRoutes.js
+++ b/server/routes/implementations/DiscordRoutes.js
@@ -1,9 +1,9 @@
 const express = require('express');
-const DiscordController = require('../../controllers/discordController');
-const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
-const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
-const discordValidator = require('../../validators/discordValidators');
-const catchAsync = require('../../utils/catchAsync');
+const DiscordController = require('@controllers/discordController');
+const AuthMiddleware = require('@middlewares/implementations/auth/AuthMiddleware');
+const ValidationMiddleware = require('@middlewares/implementations/validation/ValidationMiddleware');
+const discordValidator = require('@validators/discordValidators');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class DiscordRoutes extends IRoute {

--- a/server/routes/implementations/GithubRoutes.js
+++ b/server/routes/implementations/GithubRoutes.js
@@ -1,9 +1,9 @@
 const express = require('express');
-const GithubController = require('../../controllers/githubController');
-const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
-const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
-const githubValidator = require('../../validators/githubValidators');
-const catchAsync = require('../../utils/catchAsync');
+const GithubController = require('@controllers/githubController');
+const AuthMiddleware = require('@middlewares/implementations/auth/AuthMiddleware');
+const ValidationMiddleware = require('@middlewares/implementations/validation/ValidationMiddleware');
+const githubValidator = require('@validators/githubValidators');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class GithubRoutes extends IRoute {

--- a/server/routes/implementations/OrganizationRoutes.js
+++ b/server/routes/implementations/OrganizationRoutes.js
@@ -1,10 +1,10 @@
 const express = require('express');
-const OrganizationController = require('../../controllers/organizationController');
-const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
-const EmailVerifiedMiddleware = require('../../middlewares/implementations/EmailVerifiedMiddleware');
-const ValidationMiddleware = require('../../middlewares/implementations/ValidationMiddleware');
-const organizationValidator = require('../../validators/organizationValidators');
-const catchAsync = require('../../utils/catchAsync');
+const OrganizationController = require('@controllers/organizationController');
+const AuthMiddleware = require('@middlewares/implementations/auth/AuthMiddleware');
+const EmailVerifiedMiddleware = require('@middlewares/implementations/auth/EmailVerifiedMiddleware');
+const ValidationMiddleware = require('@middlewares/implementations/validation/ValidationMiddleware');
+const organizationValidator = require('@validators/organizationValidators');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class OrganizationRoutes extends IRoute {

--- a/server/routes/implementations/PaymanRoutes.js
+++ b/server/routes/implementations/PaymanRoutes.js
@@ -1,7 +1,7 @@
 const express = require('express');
-const PaymanController = require('../../controllers/paymanController');
-const AuthMiddleware = require('../../middlewares/implementations/AuthMiddleware');
-const catchAsync = require('../../utils/catchAsync');
+const PaymanController = require('@controllers/paymanController');
+const AuthMiddleware = require('@middlewares/implementations/auth/AuthMiddleware');
+const catchAsync = require('@utils/catchAsync');
 const IRoute = require('../IRoute');
 
 class PaymanRoutes extends IRoute {

--- a/server/services/database/FirestoreService.js
+++ b/server/services/database/FirestoreService.js
@@ -1,5 +1,5 @@
-const { auth, db } = require('../../utils/firebase');
-const EncryptionService = require('../misc/EncryptionService');
+const { auth, db } = require('@utils/firebase');
+const EncryptionService = require('@services/misc/EncryptionService');
 
 const SENSITIVE_KEYS = ['discordAccessToken', 'githubToken'];
 

--- a/server/services/database/RealtimeDatabaseService.js
+++ b/server/services/database/RealtimeDatabaseService.js
@@ -1,4 +1,4 @@
-const { rtdb } = require('../../utils/firebase');
+const { rtdb } = require('@utils/firebase');
 
 class RealtimeDatabaseService {
   getRef(path) {

--- a/server/services/integrations/DiscordService.js
+++ b/server/services/integrations/DiscordService.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const FirestoreService = require('../database/FirestoreService');
+const FirestoreService = require('@services/database/FirestoreService');
 const crypto = require('crypto');
 
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID;

--- a/server/services/integrations/GithubService.js
+++ b/server/services/integrations/GithubService.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const FirestoreService = require('../database/FirestoreService');
+const FirestoreService = require('@services/database/FirestoreService');
 const crypto = require('crypto');
 
 const CLIENT_ID = process.env.GITHUB_CLIENT_ID;

--- a/server/services/integrations/PaymanService.js
+++ b/server/services/integrations/PaymanService.js
@@ -1,6 +1,6 @@
 const Paymanai = require('paymanai');
-const FirestoreService = require('../database/FirestoreService');
-const EmailService = require('../misc/EmailService');
+const FirestoreService = require('@services/database/FirestoreService');
+const EmailService = require('@services/misc/EmailService');
 
 class PaymanService {
   getClient(apiKey) {

--- a/server/services/misc/EmailService.js
+++ b/server/services/misc/EmailService.js
@@ -1,5 +1,5 @@
-const sendMail = require('../../utils/mailer');
-const FirestoreService = require('../database/FirestoreService');
+const sendMail = require('@utils/mailer');
+const FirestoreService = require('@services/database/FirestoreService');
 
 class EmailService {
   async sendVerificationEmail({ to, token }) {

--- a/server/services/misc/LoginThrottleService.js
+++ b/server/services/misc/LoginThrottleService.js
@@ -1,4 +1,4 @@
-const RealtimeDatabaseService = require('../database/RealtimeDatabaseService');
+const RealtimeDatabaseService = require('@services/database/RealtimeDatabaseService');
 
 class LoginThrottleService {
   getUserKey(email) {

--- a/server/services/misc/OTPTokenService.js
+++ b/server/services/misc/OTPTokenService.js
@@ -1,5 +1,5 @@
 const crypto = require('crypto');
-const FirestoreService = require('../database/FirestoreService');
+const FirestoreService = require('@services/database/FirestoreService');
 
 const OTP_COLLECTION = 'otp_tokens';
 const OTP_EXPIRY_MINUTES = 15;

--- a/server/services/user/ContributorService.js
+++ b/server/services/user/ContributorService.js
@@ -1,6 +1,6 @@
-const FirestoreService = require('../database/FirestoreService');
-const RealtimeDatabaseService = require('../database/RealtimeDatabaseService');
-const EmailService = require('../misc/EmailService');
+const FirestoreService = require('@services/database/FirestoreService');
+const RealtimeDatabaseService = require('@services/database/RealtimeDatabaseService');
+const EmailService = require('@services/misc/EmailService');
 
 class ContributorService {
   async applyToBounty(bountyId, userId) {

--- a/server/services/user/OrganizationService.js
+++ b/server/services/user/OrganizationService.js
@@ -1,6 +1,6 @@
-const FirestoreService = require('../database/FirestoreService');
-const RealtimeDatabaseService = require('../database/RealtimeDatabaseService');
-const postToDiscord = require('../../utils/postToDiscord');
+const FirestoreService = require('@services/database/FirestoreService');
+const RealtimeDatabaseService = require('@services/database/RealtimeDatabaseService');
+const postToDiscord = require('@utils/postToDiscord');
 
 class OrganizationService {
   async createBounty(values, userId) {

--- a/server/services/user/UserService.js
+++ b/server/services/user/UserService.js
@@ -1,9 +1,9 @@
-const FirestoreService = require('../database/FirestoreService');
+const FirestoreService = require('@services/database/FirestoreService');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
-const LoginThrottleService = require('../misc/LoginThrottleService');
-const OTPService = require('../misc/OTPTokenService');
-const EmailService = require('../misc/EmailService');
+const LoginThrottleService = require('@services/misc/LoginThrottleService');
+const OTPService = require('@services/misc/OTPTokenService');
+const EmailService = require('@services/misc/EmailService');
 
 const MAX_ATTEMPTS = Number(process.env.MAX_LOGIN_ATTEMPTS || 3);
 const SALT_ROUNDS = 10;

--- a/server/sockets/chat.js
+++ b/server/sockets/chat.js
@@ -1,5 +1,5 @@
 const { Server } = require('socket.io');
-const { rtdb } = require('../utils/firebase');
+const { rtdb } = require('@utils/firebase');
 
 const listeners = {};
 

--- a/server/utils/postToDiscord.js
+++ b/server/utils/postToDiscord.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const FirestoreService = require('../services/database/FirestoreService');
+const FirestoreService = require('@services/database/FirestoreService');
 
 const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 


### PR DESCRIPTION
## Summary
- organize middlewares by feature subfolders
- configure module-alias and update imports to use project root aliases
- update middleware loader to read nested directories
- create `OTPTokenCleanupJob` cron task
- use aliases across controllers, services, routes and utils

## Testing
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_6841ffe0185c8326acb136123f5ca66c