### PR TITLE
[Feature] Refactor frontend hooks and components

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,11 +5,11 @@ import {
   Route,
   Navigate,
 } from 'react-router-dom';
-import { ConfigProvider, theme } from 'antd';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import { routes } from './routes/RoutesConfig';
 
 import { OrganizationPaymentHistory, ContributorPaymentHistory } from './pages';
+import { Suspense } from 'react';
 
 const AppRoutes = () => {
   const { user } = useAuth();
@@ -53,18 +53,13 @@ const AppRoutes = () => {
 
 const App = () => {
   return (
-    <ConfigProvider
-      theme={{
-        algorithm: theme.darkAlgorithm,
-        token: { fontFamily: 'Reddit Sans, sans-serif' },
-      }}
-    >
-      <AuthProvider>
-        <Router>
+    <AuthProvider>
+      <Router>
+        <Suspense fallback={null}>
           <AppRoutes />
-        </Router>
-      </AuthProvider>
-    </ConfigProvider>
+        </Suspense>
+      </Router>
+    </AuthProvider>
   );
 };
 

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -2,19 +2,21 @@ import React, { useState } from 'react';
 import { Layout, Button, Space, Drawer, Grid } from 'antd';
 import { MenuOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 const { Header } = Layout;
 
 const Navbar = () => {
   const navigate = useNavigate();
-  const localUser = JSON.parse(localStorage.getItem('payman-user'));
-  const role = localUser?.role;
+  const { user, setUser } = useAuth();
+  const role = user?.role;
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const screens = Grid.useBreakpoint();
 
   const handleLogout = () => {
     localStorage.removeItem('payman-user');
+    setUser(null);
     navigate('/login');
   };
 

--- a/client/src/components/common/PaymentHistoryTable.js
+++ b/client/src/components/common/PaymentHistoryTable.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Table, Typography } from 'antd';
+
+const { Title } = Typography;
+
+const PaymentHistoryTable = React.memo(
+  ({ fetchPayments, userId, columns, title }) => {
+    const [loading, setLoading] = useState(true);
+    const [data, setData] = useState([]);
+
+    useEffect(() => {
+      const load = async () => {
+        const res = await fetchPayments(userId);
+        setData(res);
+        setLoading(false);
+      };
+      load();
+    }, [fetchPayments, userId]);
+
+    return (
+      <div className="page-container">
+        <Card
+          title={
+            <Title level={4} style={{ color: '#fff' }}>
+              {title}
+            </Title>
+          }
+          style={{ backgroundColor: '#1f1f1f' }}
+          bodyStyle={{ padding: '1rem' }}
+        >
+          <Table
+            dataSource={data}
+            columns={columns}
+            loading={loading}
+            rowKey={(record) => record.id}
+            pagination={{ pageSize: 5 }}
+            scroll={{ x: 'max-content' }}
+          />
+        </Card>
+      </div>
+    );
+  }
+);
+
+export default PaymentHistoryTable;

--- a/client/src/components/contributor/BountyCard.js
+++ b/client/src/components/contributor/BountyCard.js
@@ -3,6 +3,7 @@ import { Card, Typography, Tag, Button, Col } from 'antd';
 import { applyToBounty, unassignSelf } from '../../api/contributor/bounties';
 import toast from '../../utils/toast';
 import formatDateBounty from '../../utils/formatDateBounty';
+import { useAuth } from '../../context/AuthContext';
 
 const { Text } = Typography;
 
@@ -20,8 +21,8 @@ const BountyCard = ({
   onOpenSubmitModal,
   onOpenChat,
 }) => {
-  const emailVerified =
-    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
+  const { user } = useAuth();
+  const emailVerified = user?.emailVerified || false;
   const handleApplyToBounty = async () => {
     if (!emailVerified) {
       toast.warning('Please verify your email before applying');

--- a/client/src/components/contributor/SubmitWorkModal.js
+++ b/client/src/components/contributor/SubmitWorkModal.js
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 import { Modal, Input, Grid } from 'antd';
 import { submitWork } from '../../api/contributor/bounties';
 import toast from '../../utils/toast';
+import { useAuth } from '../../context/AuthContext';
 
 const SubmitWorkModal = ({ visible, bountyId, onCancel, onSubmitSuccess }) => {
   const [submission, setSubmission] = useState('');
-  const emailVerified =
-    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
+  const { user } = useAuth();
+  const emailVerified = user?.emailVerified || false;
 
   const handleSubmitWork = async () => {
     if (!emailVerified) {

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,4 +1,5 @@
 import Navbar from './Navbar';
 import EmailVerificationBanner from './EmailVerificationBanner';
+import PaymentHistoryTable from './common/PaymentHistoryTable';
 
-export { Navbar, EmailVerificationBanner };
+export { Navbar, EmailVerificationBanner, PaymentHistoryTable };

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { Modal, Form, Input, DatePicker, Button, Tooltip, Grid } from 'antd';
 import { createBounty } from '../../api/organization/bounties';
 import toast from '../../utils/toast';
+import { useAuth } from '../../context/AuthContext';
 
 const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
   const [form] = Form.useForm();
-  const emailVerified =
-    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
+  const { user } = useAuth();
+  const emailVerified = user?.emailVerified || false;
 
   const handleCreate = async () => {
     if (!emailVerified) {

--- a/client/src/hooks/useEmailVerification.js
+++ b/client/src/hooks/useEmailVerification.js
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { sendEmailVerification, verifyEmailToken } from '../api/auth';
+import { useAuth } from '../context/AuthContext';
+import toast from '../utils/toast';
+
+const useEmailVerification = (email) => {
+  const { user, setUser } = useAuth();
+  const [token, setToken] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
+
+  const handleSendVerification = async () => {
+    try {
+      await sendEmailVerification(email);
+      toast.success('Verification email sent');
+      setOtpSent(true);
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
+  const handleVerifyToken = async () => {
+    try {
+      await verifyEmailToken(email, token);
+      toast.success('Email verified');
+      const updated = { ...user, emailVerified: true };
+      localStorage.setItem('payman-user', JSON.stringify(updated));
+      setUser(updated);
+      setOtpSent(false);
+    } catch (err) {
+      toast.error(err.message);
+    }
+  };
+
+  return {
+    token,
+    setToken,
+    otpSent,
+    emailVerified: user?.emailVerified || false,
+    handleSendVerification,
+    handleVerifyToken,
+  };
+};
+
+export default useEmailVerification;

--- a/client/src/pages/contributor/ContributorDashboard.js
+++ b/client/src/pages/contributor/ContributorDashboard.js
@@ -9,6 +9,7 @@ import {
   ChatModal,
 } from '../../components/contributor';
 import EmailVerificationBanner from '../../components/EmailVerificationBanner';
+import { useAuth } from '../../context/AuthContext';
 
 const { Title } = Typography;
 
@@ -20,7 +21,7 @@ const ContributorDashboard = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const [chatModalVisible, setChatModalVisible] = useState(false);
 
-  const user = JSON.parse(localStorage.getItem('payman-user')) || {};
+  const { user } = useAuth();
   const uid = user.uid;
   const emailVerified = user.emailVerified;
 

--- a/client/src/pages/contributor/ContributorProfile.js
+++ b/client/src/pages/contributor/ContributorProfile.js
@@ -13,8 +13,8 @@ import {
   fetchContributorProfile,
   saveContributorProfile,
 } from '../../api/contributor/profile';
-import { sendEmailVerification, verifyEmailToken } from '../../api/auth';
 import { useAuth } from '../../context/AuthContext';
+import useEmailVerification from '../../hooks/useEmailVerification';
 import toast from '../../utils/toast';
 
 const { Content } = Layout;
@@ -26,11 +26,14 @@ const ContributorProfile = () => {
   const { user } = useAuth();
   const email = user.email;
   const uid = user.uid;
-  const emailVerified =
-    JSON.parse(localStorage.getItem('payman-user'))?.emailVerified || false;
-
-  const [token, setToken] = useState('');
-  const [otpSent, setOtpSent] = useState(false);
+  const {
+    token,
+    setToken,
+    otpSent,
+    emailVerified,
+    handleSendVerification,
+    handleVerifyToken,
+  } = useEmailVerification(email);
 
   const defaultFields = {
     name: '',
@@ -68,28 +71,6 @@ const ContributorProfile = () => {
       toast.success('Profile loaded successfully');
     } catch (err) {
       toast.error('Failed to save contributor profile');
-    }
-  };
-
-  const handleSendVerification = async () => {
-    try {
-      await sendEmailVerification(email);
-      toast.success('Verification email sent');
-      setOtpSent(true);
-    } catch (err) {
-      toast.error(err.message);
-    }
-  };
-
-  const handleVerifyToken = async () => {
-    try {
-      await verifyEmailToken(email, token);
-      toast.success('Email verified');
-      user.emailVerified = true;
-      localStorage.setItem('payman-user', JSON.stringify(user));
-      setOtpSent(false);
-    } catch (err) {
-      toast.error(err.message);
     }
   };
 

--- a/client/src/pages/contributor/PaymentHistory.js
+++ b/client/src/pages/contributor/PaymentHistory.js
@@ -1,10 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { Table, Card, Typography, Tag } from 'antd';
+import React from 'react';
+import { Tag } from 'antd';
 import { getContributorPayments } from '../../api/contributor/payments';
 import formatDate from '../../utils/formatDate';
-import toast from '../../utils/toast';
-
-const { Title } = Typography;
+import { PaymentHistoryTable } from '../../components';
 
 const columns = [
   {
@@ -44,46 +42,13 @@ const columns = [
   },
 ];
 
-const ContributorPaymentHistory = ({ user }) => {
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState([]);
-
-  useEffect(() => {
-    const fetchPayments = async () => {
-      try {
-        const res = await getContributorPayments(user.uid);
-        setData(res);
-      } catch (err) {
-        toast.error('Failed to fetch payments');
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchPayments();
-  }, [user.uid]);
-
-  return (
-    <div className="page-container">
-      <Card
-        title={
-          <Title level={4} style={{ color: '#fff' }}>
-            Your Payment History
-          </Title>
-        }
-        style={{ backgroundColor: '#1f1f1f' }}
-        bodyStyle={{ padding: '1rem' }}
-      >
-        <Table
-          dataSource={data}
-          columns={columns}
-          loading={loading}
-          rowKey={(record) => record.id}
-          pagination={{ pageSize: 5 }}
-          scroll={{ x: 'max-content' }}
-        />
-      </Card>
-    </div>
-  );
-};
+const ContributorPaymentHistory = ({ user }) => (
+  <PaymentHistoryTable
+    fetchPayments={getContributorPayments}
+    userId={user.uid}
+    columns={columns}
+    title="Your Payment History"
+  />
+);
 
 export default ContributorPaymentHistory;

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,14 +1,28 @@
-import Login from './auth/Login';
-import Signup from './auth/Signup';
-import ForgotPassword from './auth/ForgotPassword';
-import Dashboard from './Dashboard';
-import Landing from './Landing';
-import OrganizationDashboard from './organization/OrganizationDashboard';
-import ContributorDashboard from './contributor/ContributorDashboard';
-import OrganizationProfile from './organization/OrganizationProfile';
-import ContributorProfile from './contributor/ContributorProfile';
-import OrganizationPaymentHistory from './organization/PaymentHistory';
-import ContributorPaymentHistory from './contributor/PaymentHistory';
+import { lazy } from 'react';
+
+const Login = lazy(() => import('./auth/Login'));
+const Signup = lazy(() => import('./auth/Signup'));
+const ForgotPassword = lazy(() => import('./auth/ForgotPassword'));
+const Dashboard = lazy(() => import('./Dashboard'));
+const Landing = lazy(() => import('./Landing'));
+const OrganizationDashboard = lazy(
+  () => import('./organization/OrganizationDashboard')
+);
+const ContributorDashboard = lazy(
+  () => import('./contributor/ContributorDashboard')
+);
+const OrganizationProfile = lazy(
+  () => import('./organization/OrganizationProfile')
+);
+const ContributorProfile = lazy(
+  () => import('./contributor/ContributorProfile')
+);
+const OrganizationPaymentHistory = lazy(
+  () => import('./organization/PaymentHistory')
+);
+const ContributorPaymentHistory = lazy(
+  () => import('./contributor/PaymentHistory')
+);
 
 export {
   Login,

--- a/client/src/pages/organization/OrganizationDashboard.js
+++ b/client/src/pages/organization/OrganizationDashboard.js
@@ -11,6 +11,7 @@ import {
 } from '../../components/organization';
 import EmailVerificationBanner from '../../components/EmailVerificationBanner';
 import toast from '../../utils/toast';
+import { useAuth } from '../../context/AuthContext';
 
 const { Title } = Typography;
 
@@ -22,7 +23,7 @@ const OrganizationDashboard = () => {
   const [chatBountyId, setChatBountyId] = useState(null);
   const [selectedBounty, setSelectedBounty] = useState(null);
 
-  const user = JSON.parse(localStorage.getItem('payman-user')) || {};
+  const { user } = useAuth();
   const uid = user.uid;
   const emailVerified = user.emailVerified;
 

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -19,7 +19,8 @@ import {
   // PaymanIntegration,
 } from '../../components/organization';
 import toast from '../../utils/toast';
-import { sendEmailVerification, verifyEmailToken } from '../../api/auth';
+import { useAuth } from '../../context/AuthContext';
+import useEmailVerification from '../../hooks/useEmailVerification';
 
 const { Content } = Layout;
 const { Title, Text } = Typography;
@@ -28,12 +29,17 @@ const OrganizationProfile = () => {
   const [loading, setLoading] = useState(true);
   const [form] = Form.useForm();
   const [profile, setProfile] = useState({});
-  const [token, setToken] = useState('');
-  const [otpSent, setOtpSent] = useState(false);
-  const user = JSON.parse(localStorage.getItem('payman-user')) || {};
+  const { user } = useAuth();
   const email = user.email || '';
   const uid = user.uid;
-  const emailVerified = user.emailVerified || false;
+  const {
+    token,
+    setToken,
+    otpSent,
+    emailVerified,
+    handleSendVerification,
+    handleVerifyToken,
+  } = useEmailVerification(email);
 
   const defaultFields = {
     companyName: '',
@@ -69,28 +75,6 @@ const OrganizationProfile = () => {
       toast.success('Profile updated successfully');
     } catch (err) {
       toast.error('Failed to update profile');
-    }
-  };
-
-  const handleSendVerification = async () => {
-    try {
-      await sendEmailVerification(email);
-      toast.success('Verification email sent');
-      setOtpSent(true);
-    } catch (err) {
-      toast.error(err.message);
-    }
-  };
-
-  const handleVerifyToken = async () => {
-    try {
-      await verifyEmailToken(email, token);
-      toast.success('Email verified');
-      user.emailVerified = true;
-      localStorage.setItem('payman-user', JSON.stringify(user));
-      setOtpSent(false);
-    } catch (err) {
-      toast.error(err.message);
     }
   };
 

--- a/client/src/pages/organization/PaymentHistory.js
+++ b/client/src/pages/organization/PaymentHistory.js
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import { Table, Card, Typography, Tag } from 'antd';
+import React from 'react';
+import { Tag } from 'antd';
 import { getOrganizationPayments } from '../../api/organization/payments';
 import formatDate from '../../utils/formatDate';
-
-const { Title } = Typography;
+import { PaymentHistoryTable } from '../../components';
 
 const columns = [
   {
@@ -43,41 +42,13 @@ const columns = [
   },
 ];
 
-const OrganizationPaymentHistory = ({ user }) => {
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState([]);
-
-  useEffect(() => {
-    const fetchPayments = async () => {
-      const res = await getOrganizationPayments(user.uid);
-      setData(res);
-      setLoading(false);
-    };
-    fetchPayments();
-  }, [user.uid]);
-
-  return (
-    <div className="page-container">
-      <Card
-        title={
-          <Title level={4} style={{ color: '#fff' }}>
-            Payment History
-          </Title>
-        }
-        style={{ backgroundColor: '#1f1f1f' }}
-        bodyStyle={{ padding: '1rem' }}
-      >
-        <Table
-          dataSource={data}
-          columns={columns}
-          loading={loading}
-          rowKey={(record) => record.id}
-          pagination={{ pageSize: 5 }}
-          scroll={{ x: 'max-content' }}
-        />
-      </Card>
-    </div>
-  );
-};
+const OrganizationPaymentHistory = ({ user }) => (
+  <PaymentHistoryTable
+    fetchPayments={getOrganizationPayments}
+    userId={user.uid}
+    columns={columns}
+    title="Payment History"
+  />
+);
 
 export default OrganizationPaymentHistory;


### PR DESCRIPTION
## Summary
- create `useEmailVerification` hook to handle OTP logic
- add `PaymentHistoryTable` shared component
- refactor profile and dashboard pages to use `useAuth` instead of localStorage
- remove duplicate `ConfigProvider` wrapper
- lazy load pages for route-based code-splitting

## Testing
- `npm run format`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68420ae99dfc8326a7300d68b1a0e2a0