### PR TITLE
Add modern theme with dark/light toggle

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "react-router-dom": "^7.4.0",
     "react-scripts": "5.0.1",
     "socket.io-client": "^4.8.1",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "framer-motion": "^11.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -23,7 +23,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Reddit+Sans&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>The DAO Tool</title>
   </head>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -64,6 +64,7 @@ const Navbar = () => {
       )}
       <Drawer
         placement="right"
+        className="drawer-right"
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         bodyStyle={{ padding: 0 }}

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { Layout, Button, Space, Drawer, Grid } from 'antd';
-import { MenuOutlined } from '@ant-design/icons';
+import { MenuOutlined, BulbOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
 
 const { Header } = Layout;
 
@@ -10,6 +11,7 @@ const Navbar = () => {
   const navigate = useNavigate();
   const { user, setUser } = useAuth();
   const role = user?.role;
+  const { darkMode, toggleTheme } = useTheme();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const screens = Grid.useBreakpoint();
@@ -31,17 +33,14 @@ const Navbar = () => {
   return (
     <Header
       style={{
-        backgroundColor: '#1f1f1f',
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
       }}
     >
-      <div style={{ color: '#fff', fontSize: '18px', fontWeight: 'bold' }}>
+      <div style={{ fontSize: '18px', fontWeight: 'bold' }}>
         DAO{' '}
-        <span style={{ fontWeight: 'normal', fontSize: '14px', color: '#aaa' }}>
-          [{role}]
-        </span>
+        <span style={{ fontWeight: 'normal', fontSize: '14px' }}>[{role}]</span>
       </div>
       {screens.md ? (
         <Space>
@@ -54,11 +53,12 @@ const Navbar = () => {
           <Button type="primary" onClick={handleLogout}>
             Logout
           </Button>
+          <Button type="text" icon={<BulbOutlined />} onClick={toggleTheme} />
         </Space>
       ) : (
         <Button
           type="text"
-          icon={<MenuOutlined style={{ color: '#fff' }} />}
+          icon={<MenuOutlined />}
           onClick={() => setDrawerOpen(true)}
         />
       )}
@@ -93,6 +93,17 @@ const Navbar = () => {
           </Button>
           <Button type="primary" block onClick={handleLogout}>
             Logout
+          </Button>
+          <Button
+            style={{ marginTop: 8 }}
+            block
+            icon={<BulbOutlined />}
+            onClick={() => {
+              toggleTheme();
+              setDrawerOpen(false);
+            }}
+          >
+            Toggle Theme
           </Button>
         </div>
       </Drawer>

--- a/client/src/components/common/PaymentHistoryTable.js
+++ b/client/src/components/common/PaymentHistoryTable.js
@@ -20,12 +20,7 @@ const PaymentHistoryTable = React.memo(
     return (
       <div className="page-container">
         <Card
-          title={
-            <Title level={4} style={{ color: '#fff' }}>
-              {title}
-            </Title>
-          }
-          style={{ backgroundColor: '#1f1f1f' }}
+          title={<Title level={4}>{title}</Title>}
           bodyStyle={{ padding: '1rem' }}
         >
           <Table

--- a/client/src/components/contributor/BountyCard.js
+++ b/client/src/components/contributor/BountyCard.js
@@ -51,7 +51,6 @@ const BountyCard = ({
     <Col xs={24} sm={12} md={8}>
       <Card
         hoverable
-        style={{ backgroundColor: '#1f1f1f' }}
         title={<Text strong>{bounty.name}</Text>}
         extra={<Tag color={statusColors[bounty.status]}>{bounty.status}</Tag>}
       >

--- a/client/src/components/contributor/ChatModal.js
+++ b/client/src/components/contributor/ChatModal.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Modal, Input, Button, List, Grid } from 'antd';
+import { Drawer, Input, Button, List, Grid } from 'antd';
 import { listenToMessages, sendMessage } from '../../realtime/chat';
 
 const ChatModal = ({ visible, bounty, userId, onCancel }) => {
@@ -29,13 +29,13 @@ const ChatModal = ({ visible, bounty, userId, onCancel }) => {
   const screens = Grid.useBreakpoint();
 
   return (
-    <Modal
+    <Drawer
       open={visible}
       title={`Chat with ${bounty?.organizationInfo?.companyName || 'Organization'}`}
-      onCancel={onCancel}
-      footer={null}
-      width={screens.xs ? '100%' : 600}
-      bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
+      onClose={onCancel}
+      placement="right"
+      width={screens.xs ? '100%' : 500}
+      bodyStyle={{ padding: 24 }}
     >
       <List
         size="small"
@@ -62,7 +62,7 @@ const ChatModal = ({ visible, bounty, userId, onCancel }) => {
       >
         Send
       </Button>
-    </Modal>
+    </Drawer>
   );
 };
 

--- a/client/src/components/contributor/ChatModal.js
+++ b/client/src/components/contributor/ChatModal.js
@@ -34,6 +34,7 @@ const ChatModal = ({ visible, bounty, userId, onCancel }) => {
       title={`Chat with ${bounty?.organizationInfo?.companyName || 'Organization'}`}
       onClose={onCancel}
       placement="right"
+      className="drawer-right"
       width={screens.xs ? '100%' : 500}
       bodyStyle={{ padding: 24 }}
     >

--- a/client/src/components/contributor/SubmitWorkModal.js
+++ b/client/src/components/contributor/SubmitWorkModal.js
@@ -33,6 +33,7 @@ const SubmitWorkModal = ({ visible, bountyId, onCancel, onSubmitSuccess }) => {
       title="Submit Work"
       onClose={onCancel}
       placement="right"
+      className="drawer-right"
       width={screens.xs ? '100%' : 500}
       bodyStyle={{ padding: 24 }}
     >

--- a/client/src/components/contributor/SubmitWorkModal.js
+++ b/client/src/components/contributor/SubmitWorkModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Modal, Input, Grid } from 'antd';
+import { Drawer, Input, Grid, Button } from 'antd';
 import { submitWork } from '../../api/contributor/bounties';
 import toast from '../../utils/toast';
 import { useAuth } from '../../context/AuthContext';
@@ -28,21 +28,28 @@ const SubmitWorkModal = ({ visible, bountyId, onCancel, onSubmitSuccess }) => {
   const screens = Grid.useBreakpoint();
 
   return (
-    <Modal
+    <Drawer
       open={visible}
       title="Submit Work"
-      onCancel={onCancel}
-      onOk={handleSubmitWork}
-      okText="Submit"
+      onClose={onCancel}
+      placement="right"
       width={screens.xs ? '100%' : 500}
-      bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
+      bodyStyle={{ padding: 24 }}
     >
       <Input
         placeholder="Enter delivery link (GitHub, site, etc.)"
         value={submission}
         onChange={(e) => setSubmission(e.target.value)}
       />
-    </Modal>
+      <Button
+        type="primary"
+        block
+        style={{ marginTop: 8 }}
+        onClick={handleSubmitWork}
+      >
+        Submit
+      </Button>
+    </Drawer>
   );
 };
 

--- a/client/src/components/organization/BountyCard.js
+++ b/client/src/components/organization/BountyCard.js
@@ -30,7 +30,6 @@ const BountyCard = ({ bounty, onView, onChatOpen, onRefetch }) => {
     <Col xs={24} sm={12} md={8}>
       <Card
         hoverable
-        style={{ backgroundColor: '#1f1f1f' }}
         onClick={onView}
         title={<Text strong>{bounty.name}</Text>}
         extra={<Tag color={statusColors[bounty.status]}>{bounty.status}</Tag>}

--- a/client/src/components/organization/ChatModal.js
+++ b/client/src/components/organization/ChatModal.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Modal, Input, List, Grid } from 'antd';
+import { Drawer, Input, List, Grid } from 'antd';
 import { listenToMessages, sendMessage } from '../../realtime/chat';
 
 const ChatModal = ({ visible, bountyId, userId, onClose }) => {
@@ -34,13 +34,13 @@ const ChatModal = ({ visible, bountyId, userId, onClose }) => {
   const screens = Grid.useBreakpoint();
 
   return (
-    <Modal
+    <Drawer
       open={visible}
-      onCancel={handleModalClose}
+      onClose={handleModalClose}
       title="Chat with Contributor"
-      footer={null}
-      width={screens.xs ? '100%' : 600}
-      bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
+      placement="right"
+      width={screens.xs ? '100%' : 500}
+      bodyStyle={{ padding: 24 }}
     >
       <div
         style={{
@@ -68,7 +68,7 @@ const ChatModal = ({ visible, bountyId, userId, onClose }) => {
         onChange={(e) => setNewMessage(e.target.value)}
         onSearch={handleSendMessage}
       />
-    </Modal>
+    </Drawer>
   );
 };
 

--- a/client/src/components/organization/ChatModal.js
+++ b/client/src/components/organization/ChatModal.js
@@ -39,6 +39,7 @@ const ChatModal = ({ visible, bountyId, userId, onClose }) => {
       onClose={handleModalClose}
       title="Chat with Contributor"
       placement="right"
+      className="drawer-right"
       width={screens.xs ? '100%' : 500}
       bodyStyle={{ padding: 24 }}
     >

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -34,6 +34,7 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
       open={visible}
       onClose={onCancel}
       placement="right"
+      className="drawer-right"
       closeIcon={<span style={{ fontSize: '16px' }}>×</span>}
       width={screens.xs ? '100%' : 600}
       bodyStyle={{ padding: 24 }}

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Form, Input, DatePicker, Button, Tooltip, Grid } from 'antd';
+import { Drawer, Form, Input, DatePicker, Button, Tooltip, Grid } from 'antd';
 import { createBounty } from '../../api/organization/bounties';
 import toast from '../../utils/toast';
 import { useAuth } from '../../context/AuthContext';
@@ -29,14 +29,14 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
   const screens = Grid.useBreakpoint();
 
   return (
-    <Modal
+    <Drawer
       title="Create New Bounty"
       open={visible}
-      onCancel={onCancel}
-      footer={null}
+      onClose={onCancel}
+      placement="right"
       closeIcon={<span style={{ fontSize: '16px' }}>×</span>}
       width={screens.xs ? '100%' : 600}
-      bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
+      bodyStyle={{ padding: 24 }}
     >
       <Form layout="vertical" form={form}>
         <Form.Item
@@ -86,7 +86,7 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
           Create
         </Button>
       </Form>
-    </Modal>
+    </Drawer>
   );
 };
 

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -34,7 +34,7 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
       open={visible}
       onCancel={onCancel}
       footer={null}
-      closeIcon={<span style={{ color: '#fff', fontSize: '16px' }}>×</span>}
+      closeIcon={<span style={{ fontSize: '16px' }}>×</span>}
       width={screens.xs ? '100%' : 600}
       bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
     >

--- a/client/src/components/organization/DiscordIntegration.js
+++ b/client/src/components/organization/DiscordIntegration.js
@@ -66,7 +66,7 @@ const DiscordIntegration = ({ uid, profile, setProfile }) => {
 
   return (
     <>
-      <Paragraph style={{ color: '#fff', marginTop: '1rem' }}>
+      <Paragraph style={{ marginTop: '1rem' }}>
         Connect Discord to post new bounties automatically to your channel.
       </Paragraph>
 
@@ -75,7 +75,7 @@ const DiscordIntegration = ({ uid, profile, setProfile }) => {
           <Text style={{ color: '#52c41a' }}>Discord connected</Text>
 
           <Space>
-            <Text style={{ color: '#fff' }}>Enable Posting:</Text>
+            <Text>Enable Posting:</Text>
             <Switch
               checked={profile.discordEnabled}
               onChange={handleSwitchChange}
@@ -83,7 +83,7 @@ const DiscordIntegration = ({ uid, profile, setProfile }) => {
           </Space>
 
           <Space>
-            <Text style={{ color: '#fff' }}>Send:</Text>
+            <Text>Send:</Text>
             <Select
               value={profile.discordSendMode || 'own'}
               onChange={handleSendModeChange}
@@ -95,7 +95,7 @@ const DiscordIntegration = ({ uid, profile, setProfile }) => {
           </Space>
 
           <Space>
-            <Text style={{ color: '#fff' }}>Channel:</Text>
+            <Text>Channel:</Text>
             <Select
               value={profile.discordChannel || undefined}
               onChange={handleChannelSelect}

--- a/client/src/components/organization/GitHubIntegration.js
+++ b/client/src/components/organization/GitHubIntegration.js
@@ -51,7 +51,7 @@ const GitHubIntegration = ({ uid, profile, setProfile }) => {
 
   return (
     <>
-      <Paragraph style={{ color: '#fff', marginTop: '1rem' }}>
+      <Paragraph style={{ marginTop: '1rem' }}>
         Link a GitHub repo to sync issues labeled <code>dao</code> as bounties.
       </Paragraph>
 

--- a/client/src/components/organization/ViewBountyModal.js
+++ b/client/src/components/organization/ViewBountyModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Modal,
+  Drawer,
   Divider,
   Select,
   Button,
@@ -61,14 +61,18 @@ const ViewBountyModal = ({
   const screens = Grid.useBreakpoint();
 
   return (
-    <Modal
+    <Drawer
       title="Edit Bounty"
       open={visible}
-      onCancel={onCancel}
-      onOk={handleSaveUpdate}
-      okText="Save Changes"
+      onClose={onCancel}
+      extra={
+        <Button type="primary" onClick={handleSaveUpdate}>
+          Save Changes
+        </Button>
+      }
+      placement="right"
       width={screens.xs ? '100%' : 600}
-      bodyStyle={{ maxHeight: '60vh', overflowY: 'auto' }}
+      bodyStyle={{ padding: 24 }}
     >
       <Row gutter={[16, 16]}>
         <Col span={24}>
@@ -192,7 +196,7 @@ const ViewBountyModal = ({
           </>
         )}
       </Row>
-    </Modal>
+    </Drawer>
   );
 };
 

--- a/client/src/components/organization/ViewBountyModal.js
+++ b/client/src/components/organization/ViewBountyModal.js
@@ -71,6 +71,7 @@ const ViewBountyModal = ({
         </Button>
       }
       placement="right"
+      className="drawer-right"
       width={screens.xs ? '100%' : 600}
       bodyStyle={{ padding: 24 }}
     >

--- a/client/src/context/ThemeContext.js
+++ b/client/src/context/ThemeContext.js
@@ -1,0 +1,25 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext(null);
+
+export const ThemeProvider = ({ children }) => {
+  const [darkMode, setDarkMode] = useState(() => {
+    const saved = localStorage.getItem('tdt-theme');
+    return saved ? saved === 'dark' : true;
+  });
+
+  useEffect(() => {
+    document.body.className = darkMode ? 'dark' : 'light';
+    localStorage.setItem('tdt-theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
+
+  const toggleTheme = () => setDarkMode((prev) => !prev);
+
+  return (
+    <ThemeContext.Provider value={{ darkMode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,3 +35,17 @@ body.dark {
   max-width: 800px;
   margin: 0 auto 1.5rem;
 }
+.drawer-right .ant-drawer-content-wrapper {
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,6 +1,4 @@
 * {
-  left: 0;
-  top: 0;
   box-sizing: border-box;
 }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,9 +6,19 @@
 
 body,
 html {
-  background-color: #141414;
-  color: #fff;
   margin: 0;
+  font-family: 'Inter', sans-serif;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.light {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+body.dark {
+  background-color: #141414;
+  color: #ffffff;
 }
 
 .page-container {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -29,3 +29,9 @@ body.dark {
   width: 100%;
   max-width: 500px;
 }
+
+.section-card {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto 1.5rem;
+}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,20 +5,31 @@ import { ConfigProvider, theme } from 'antd';
 import 'antd/dist/reset.css';
 import './index.css';
 import { Toaster } from 'react-hot-toast';
+import { ThemeProvider, useTheme } from './context/ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
+
+const Providers = () => {
+  const { darkMode } = useTheme();
+  return (
     <ConfigProvider
       theme={{
         token: {
-          fontFamily: 'Reddit Sans, sans-serif',
+          fontFamily: 'Inter, sans-serif',
         },
-        algorithm: theme.darkAlgorithm,
+        algorithm: darkMode ? theme.darkAlgorithm : theme.defaultAlgorithm,
       }}
     >
       <App />
       <Toaster position="top-right" toastOptions={{ duration: 3000 }} />
     </ConfigProvider>
+  );
+};
+
+root.render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <Providers />
+    </ThemeProvider>
   </React.StrictMode>
 );

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -12,15 +12,13 @@ const Dashboard = () => {
   const role = user.role;
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Navbar />
       <Content className="page-container">
         {role === 'organization' && <OrganizationDashboard />}
         {role === 'contributor' && <ContributorDashboard />}
         {!role && (
-          <div style={{ color: '#fff' }}>
-            Unable to determine your role. Please contact support.
-          </div>
+          <div>Unable to determine your role. Please contact support.</div>
         )}
       </Content>
     </Layout>

--- a/client/src/pages/auth/ForgotPassword.js
+++ b/client/src/pages/auth/ForgotPassword.js
@@ -45,7 +45,7 @@ const ForgotPassword = () => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Content
         style={{
           display: 'flex',
@@ -56,12 +56,10 @@ const ForgotPassword = () => {
         <Card
           style={{
             width: 400,
-            backgroundColor: '#1f1f1f',
-            color: '#fff',
             marginTop: 100,
           }}
         >
-          <Title level={3} style={{ color: '#fff', textAlign: 'center' }}>
+          <Title level={3} style={{ textAlign: 'center' }}>
             Forgot Password
           </Title>
 

--- a/client/src/pages/auth/ForgotPassword.js
+++ b/client/src/pages/auth/ForgotPassword.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Input, Typography, Card, Layout } from 'antd';
+import { Navbar } from '../../components';
 import { useNavigate } from 'react-router-dom';
 import toast from '../../utils/toast';
 import {
@@ -46,6 +47,7 @@ const ForgotPassword = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
       <Content
         style={{
           display: 'flex',

--- a/client/src/pages/auth/Login.js
+++ b/client/src/pages/auth/Login.js
@@ -29,7 +29,7 @@ const Login = () => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Content
         style={{
           display: 'flex',
@@ -39,10 +39,10 @@ const Login = () => {
       >
         <Card
           className="form-card"
-          style={{ backgroundColor: '#1f1f1f', color: '#fff', marginTop: 100 }}
+          style={{ marginTop: 100 }}
           bodyStyle={{ padding: '1rem' }}
         >
-          <Title level={3} style={{ color: '#fff', textAlign: 'center' }}>
+          <Title level={3} style={{ textAlign: 'center' }}>
             Log In
           </Title>
           <Input

--- a/client/src/pages/auth/Login.js
+++ b/client/src/pages/auth/Login.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Input, Typography, Card, Layout, Flex } from 'antd';
+import { Navbar } from '../../components';
 import { useNavigate } from 'react-router-dom';
 import { loginUser } from '../../api/auth';
 import { saveUserToStorage } from '../../utils/localStorage';
@@ -30,6 +31,7 @@ const Login = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
       <Content
         style={{
           display: 'flex',

--- a/client/src/pages/auth/Signup.js
+++ b/client/src/pages/auth/Signup.js
@@ -38,7 +38,7 @@ const Signup = () => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Content
         style={{
           display: 'flex',
@@ -48,10 +48,10 @@ const Signup = () => {
       >
         <Card
           className="form-card"
-          style={{ backgroundColor: '#1f1f1f', color: '#fff', marginTop: 100 }}
+          style={{ marginTop: 100 }}
           bodyStyle={{ padding: '1rem' }}
         >
-          <Title level={3} style={{ color: '#fff', textAlign: 'center' }}>
+          <Title level={3} style={{ textAlign: 'center' }}>
             Sign Up
           </Title>
           <Input

--- a/client/src/pages/auth/Signup.js
+++ b/client/src/pages/auth/Signup.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Button, Input, Typography, Select, Card, Layout } from 'antd';
+import { Navbar } from '../../components';
 import { useNavigate } from 'react-router-dom';
 import { signupUser } from '../../api/auth';
 import { saveUserToStorage } from '../../utils/localStorage';
@@ -39,6 +40,7 @@ const Signup = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
       <Content
         style={{
           display: 'flex',

--- a/client/src/pages/contributor/ContributorDashboard.js
+++ b/client/src/pages/contributor/ContributorDashboard.js
@@ -58,15 +58,11 @@ const ContributorDashboard = () => {
 
   return (
     <div className="page-container">
-      <Title level={3} style={{ color: '#fff' }}>
-        Available Bounties
-      </Title>
+      <Title level={3}>Available Bounties</Title>
       {!emailVerified && <EmailVerificationBanner email={user.email} />}
 
       <div style={{ marginBottom: '1rem' }}>
-        <span style={{ color: '#fff', marginRight: '0.5rem' }}>
-          Filter by Matching Skills
-        </span>
+        <span style={{ marginRight: '0.5rem' }}>Filter by Matching Skills</span>
         <Switch
           checked={filterBySkills}
           onChange={(checked) => setFilterBySkills(checked)}

--- a/client/src/pages/contributor/ContributorProfile.js
+++ b/client/src/pages/contributor/ContributorProfile.js
@@ -9,6 +9,7 @@ import {
   Space,
   Tag,
 } from 'antd';
+import { Navbar } from '../../components';
 import {
   fetchContributorProfile,
   saveContributorProfile,
@@ -76,16 +77,11 @@ const ContributorProfile = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Content
-        className="page-container"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
+      <Navbar />
+      <Content className="page-container" style={{ padding: '2rem' }}>
         <Card
           className="form-card"
+          style={{ maxWidth: 800, margin: '0 auto' }}
           loading={loading}
           bodyStyle={{ padding: '1rem' }}
         >

--- a/client/src/pages/contributor/ContributorProfile.js
+++ b/client/src/pages/contributor/ContributorProfile.js
@@ -9,6 +9,7 @@ import {
   Space,
   Tag,
 } from 'antd';
+import { motion } from 'framer-motion';
 import { Navbar } from '../../components';
 import {
   fetchContributorProfile,
@@ -79,71 +80,90 @@ const ContributorProfile = () => {
     <Layout style={{ minHeight: '100vh' }}>
       <Navbar />
       <Content className="page-container" style={{ padding: '2rem' }}>
-        <Card
-          className="form-card"
-          style={{ maxWidth: 800, margin: '0 auto' }}
-          loading={loading}
-          bodyStyle={{ padding: '1rem' }}
-        >
-          <Title level={3} style={{ textAlign: 'center' }}>
-            Contributor Profile
-          </Title>
-          <Form form={form} layout="vertical" onFinish={handleSubmit}>
-            <Form.Item name="name" label="Full Name">
-              <Input placeholder="John Doe" />
-            </Form.Item>
-            <Form.Item name="email" label="Email">
-              <Input value={email} disabled />
-            </Form.Item>
-            {!emailVerified ? (
-              <>
-                <Space style={{ marginBottom: 10 }}>
-                  <Tag color="red">Email not verified</Tag>
-                  <Button size="small" onClick={handleSendVerification}>
-                    Send Verification OTP
-                  </Button>
-                </Space>
-                {otpSent && (
-                  <Space direction="vertical" style={{ width: '100%' }}>
-                    <Input
-                      placeholder="Enter OTP"
-                      value={token}
-                      onChange={(e) => setToken(e.target.value)}
-                    />
-                    <Button block type="primary" onClick={handleVerifyToken}>
-                      Verify Email
+        <Title level={3} style={{ textAlign: 'center', marginBottom: '1rem' }}>
+          Contributor Profile
+        </Title>
+        <Form form={form} layout="vertical" onFinish={handleSubmit}>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Card
+              className="section-card"
+              title="Basic Information"
+              loading={loading}
+            >
+              <Form.Item name="name" label="Full Name">
+                <Input placeholder="John Doe" />
+              </Form.Item>
+              <Form.Item name="email" label="Email">
+                <Input value={email} disabled />
+              </Form.Item>
+              {!emailVerified ? (
+                <>
+                  <Space style={{ marginBottom: 10 }}>
+                    <Tag color="red">Email not verified</Tag>
+                    <Button size="small" onClick={handleSendVerification}>
+                      Send Verification OTP
                     </Button>
                   </Space>
-                )}
-              </>
-            ) : (
-              <Tag color="green" style={{ marginBottom: 10 }}>
-                Email Verified
-              </Tag>
-            )}
-            <Form.Item name="roleTitle" label="Your Role / Title">
-              <Input placeholder="Frontend Engineer, Designer, etc." />
-            </Form.Item>
-            <Form.Item name="skills" label="Skills (comma separated)">
-              <Input placeholder="React, Figma, Node.js" />
-            </Form.Item>
-            <Form.Item name="portfolio" label="Portfolio URL or GitHub">
-              <Input placeholder="https://yourportfolio.com" />
-            </Form.Item>
-            <Form.Item name="linkedin" label="LinkedIn Profile">
-              <Input placeholder="https://linkedin.com/in/yourprofile" />
-            </Form.Item>
-            <Form.Item name="accountNumber" label="Bank Account Number">
-              <Input placeholder="1234567890" />
-            </Form.Item>
-            <Form.Item name="routingNumber" label="Bank Routing Number">
-              <Input placeholder="1234567890" />
-            </Form.Item>
-            <Button type="primary" htmlType="submit" block>
-              Save
-            </Button>
-          </Form>
-        </Card>
+                  {otpSent && (
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      <Input
+                        placeholder="Enter OTP"
+                        value={token}
+                        onChange={(e) => setToken(e.target.value)}
+                      />
+                      <Button block type="primary" onClick={handleVerifyToken}>
+                        Verify Email
+                      </Button>
+                    </Space>
+                  )}
+                </>
+              ) : (
+                <Tag color="green" style={{ marginBottom: 10 }}>
+                  Email Verified
+                </Tag>
+              )}
+              <Form.Item name="roleTitle" label="Your Role / Title">
+                <Input placeholder="Frontend Engineer, Designer, etc." />
+              </Form.Item>
+              <Form.Item name="skills" label="Skills (comma separated)">
+                <Input placeholder="React, Figma, Node.js" />
+              </Form.Item>
+              <Form.Item name="portfolio" label="Portfolio URL or GitHub">
+                <Input placeholder="https://yourportfolio.com" />
+              </Form.Item>
+              <Form.Item name="linkedin" label="LinkedIn Profile">
+                <Input placeholder="https://linkedin.com/in/yourprofile" />
+              </Form.Item>
+            </Card>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+          >
+            <Card
+              className="section-card"
+              title="Payment Details"
+              loading={loading}
+            >
+              <Form.Item name="accountNumber" label="Bank Account Number">
+                <Input placeholder="1234567890" />
+              </Form.Item>
+              <Form.Item name="routingNumber" label="Bank Routing Number">
+                <Input placeholder="1234567890" />
+              </Form.Item>
+            </Card>
+          </motion.div>
+
+          <Button type="primary" htmlType="submit" block>
+            Save
+          </Button>
+        </Form>
       </Content>
     </Layout>
   );

--- a/client/src/pages/contributor/ContributorProfile.js
+++ b/client/src/pages/contributor/ContributorProfile.js
@@ -75,7 +75,7 @@ const ContributorProfile = () => {
   };
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Content
         className="page-container"
         style={{
@@ -86,11 +86,10 @@ const ContributorProfile = () => {
       >
         <Card
           className="form-card"
-          style={{ backgroundColor: '#1f1f1f' }}
           loading={loading}
           bodyStyle={{ padding: '1rem' }}
         >
-          <Title level={3} style={{ color: '#fff', textAlign: 'center' }}>
+          <Title level={3} style={{ textAlign: 'center' }}>
             Contributor Profile
           </Title>
           <Form form={form} layout="vertical" onFinish={handleSubmit}>
@@ -98,7 +97,7 @@ const ContributorProfile = () => {
               <Input placeholder="John Doe" />
             </Form.Item>
             <Form.Item name="email" label="Email">
-              <Input value={email} disabled style={{ color: '#ccc' }} />
+              <Input value={email} disabled />
             </Form.Item>
             {!emailVerified ? (
               <>

--- a/client/src/pages/contributor/ContributorProfile.js
+++ b/client/src/pages/contributor/ContributorProfile.js
@@ -8,7 +8,9 @@ import {
   Form,
   Space,
   Tag,
+  Menu,
 } from 'antd';
+import { UserOutlined, CreditCardOutlined } from '@ant-design/icons';
 import { motion } from 'framer-motion';
 import { Navbar } from '../../components';
 import {
@@ -19,12 +21,13 @@ import { useAuth } from '../../context/AuthContext';
 import useEmailVerification from '../../hooks/useEmailVerification';
 import toast from '../../utils/toast';
 
-const { Content } = Layout;
+const { Content, Sider } = Layout;
 const { Title } = Typography;
 
 const ContributorProfile = () => {
   const [loading, setLoading] = useState(true);
   const [form] = Form.useForm();
+  const [section, setSection] = useState('basic');
   const { user } = useAuth();
   const email = user.email;
   const uid = user.uid;
@@ -79,92 +82,118 @@ const ContributorProfile = () => {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Navbar />
-      <Content className="page-container" style={{ padding: '2rem' }}>
-        <Title level={3} style={{ textAlign: 'center', marginBottom: '1rem' }}>
-          Contributor Profile
-        </Title>
-        <Form form={form} layout="vertical" onFinish={handleSubmit}>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
+      <Layout>
+        <Sider breakpoint="lg" collapsedWidth="0" width={200}>
+          <Menu
+            mode="inline"
+            selectedKeys={[section]}
+            onClick={(e) => setSection(e.key)}
+            items={[
+              { key: 'basic', icon: <UserOutlined />, label: 'Basic Info' },
+              {
+                key: 'payment',
+                icon: <CreditCardOutlined />,
+                label: 'Payments',
+              },
+            ]}
+          />
+        </Sider>
+        <Content className="page-container" style={{ padding: '2rem' }}>
+          <Title
+            level={3}
+            style={{ textAlign: 'center', marginBottom: '1rem' }}
           >
-            <Card
-              className="section-card"
-              title="Basic Information"
-              loading={loading}
+            Contributor Profile
+          </Title>
+          <Form form={form} layout="vertical" onFinish={handleSubmit}>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              hidden={section !== 'basic'}
             >
-              <Form.Item name="name" label="Full Name">
-                <Input placeholder="John Doe" />
-              </Form.Item>
-              <Form.Item name="email" label="Email">
-                <Input value={email} disabled />
-              </Form.Item>
-              {!emailVerified ? (
-                <>
-                  <Space style={{ marginBottom: 10 }}>
-                    <Tag color="red">Email not verified</Tag>
-                    <Button size="small" onClick={handleSendVerification}>
-                      Send Verification OTP
-                    </Button>
-                  </Space>
-                  {otpSent && (
-                    <Space direction="vertical" style={{ width: '100%' }}>
-                      <Input
-                        placeholder="Enter OTP"
-                        value={token}
-                        onChange={(e) => setToken(e.target.value)}
-                      />
-                      <Button block type="primary" onClick={handleVerifyToken}>
-                        Verify Email
+              <Card
+                className="section-card"
+                title="Basic Information"
+                loading={loading}
+              >
+                <Form.Item name="name" label="Full Name">
+                  <Input placeholder="John Doe" />
+                </Form.Item>
+                <Form.Item name="email" label="Email">
+                  <Input value={email} disabled />
+                </Form.Item>
+                {!emailVerified ? (
+                  <>
+                    <Space style={{ marginBottom: 10 }}>
+                      <Tag color="red">Email not verified</Tag>
+                      <Button size="small" onClick={handleSendVerification}>
+                        Send Verification OTP
                       </Button>
                     </Space>
-                  )}
-                </>
-              ) : (
-                <Tag color="green" style={{ marginBottom: 10 }}>
-                  Email Verified
-                </Tag>
-              )}
-              <Form.Item name="roleTitle" label="Your Role / Title">
-                <Input placeholder="Frontend Engineer, Designer, etc." />
-              </Form.Item>
-              <Form.Item name="skills" label="Skills (comma separated)">
-                <Input placeholder="React, Figma, Node.js" />
-              </Form.Item>
-              <Form.Item name="portfolio" label="Portfolio URL or GitHub">
-                <Input placeholder="https://yourportfolio.com" />
-              </Form.Item>
-              <Form.Item name="linkedin" label="LinkedIn Profile">
-                <Input placeholder="https://linkedin.com/in/yourprofile" />
-              </Form.Item>
-            </Card>
-          </motion.div>
+                    {otpSent && (
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        <Input
+                          placeholder="Enter OTP"
+                          value={token}
+                          onChange={(e) => setToken(e.target.value)}
+                        />
+                        <Button
+                          block
+                          type="primary"
+                          onClick={handleVerifyToken}
+                        >
+                          Verify Email
+                        </Button>
+                      </Space>
+                    )}
+                  </>
+                ) : (
+                  <Tag color="green" style={{ marginBottom: 10 }}>
+                    Email Verified
+                  </Tag>
+                )}
+                <Form.Item name="roleTitle" label="Your Role / Title">
+                  <Input placeholder="Frontend Engineer, Designer, etc." />
+                </Form.Item>
+                <Form.Item name="skills" label="Skills (comma separated)">
+                  <Input placeholder="React, Figma, Node.js" />
+                </Form.Item>
+                <Form.Item name="portfolio" label="Portfolio URL or GitHub">
+                  <Input placeholder="https://yourportfolio.com" />
+                </Form.Item>
+                <Form.Item name="linkedin" label="LinkedIn Profile">
+                  <Input placeholder="https://linkedin.com/in/yourprofile" />
+                </Form.Item>
+              </Card>
+            </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, delay: 0.1 }}
-          >
-            <Card
-              className="section-card"
-              title="Payment Details"
-              loading={loading}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.1 }}
+              hidden={section !== 'payment'}
             >
-              <Form.Item name="accountNumber" label="Bank Account Number">
-                <Input placeholder="1234567890" />
-              </Form.Item>
-              <Form.Item name="routingNumber" label="Bank Routing Number">
-                <Input placeholder="1234567890" />
-              </Form.Item>
-            </Card>
-          </motion.div>
+              <Card
+                className="section-card"
+                title="Payment Details"
+                loading={loading}
+              >
+                <Form.Item name="accountNumber" label="Bank Account Number">
+                  <Input placeholder="1234567890" />
+                </Form.Item>
+                <Form.Item name="routingNumber" label="Bank Routing Number">
+                  <Input placeholder="1234567890" />
+                </Form.Item>
+              </Card>
+            </motion.div>
 
-          <Button type="primary" htmlType="submit" block>
-            Save
-          </Button>
-        </Form>
-      </Content>
+            <Button type="primary" htmlType="submit" block>
+              Save
+            </Button>
+          </Form>
+        </Content>
+      </Layout>
     </Layout>
   );
 };

--- a/client/src/pages/contributor/Insights.js
+++ b/client/src/pages/contributor/Insights.js
@@ -84,13 +84,8 @@ const ContributorInsights = ({ user }) => {
     .sort((a, b) => a.date.localeCompare(b.date));
 
   const lineChart = (
-    <Card
-      style={{ backgroundColor: '#1f1f1f' }}
-      bodyStyle={{ padding: '1rem' }}
-    >
-      <Title level={4} style={{ color: '#fff' }}>
-        Bounties Submitted
-      </Title>
+    <Card bodyStyle={{ padding: '1rem' }}>
+      <Title level={4}>Bounties Submitted</Title>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart
           data={monthlyData}
@@ -107,13 +102,8 @@ const ContributorInsights = ({ user }) => {
   );
 
   const pieChart = (
-    <Card
-      style={{ backgroundColor: '#1f1f1f' }}
-      bodyStyle={{ padding: '1rem' }}
-    >
-      <Title level={4} style={{ color: '#fff' }}>
-        Bounty Status Distribution
-      </Title>
+    <Card bodyStyle={{ padding: '1rem' }}>
+      <Title level={4}>Bounty Status Distribution</Title>
       <ResponsiveContainer width="100%" height={400}>
         <PieChart>
           <Pie

--- a/client/src/pages/contributor/Insights.js
+++ b/client/src/pages/contributor/Insights.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Typography, Tag, Tabs } from 'antd';
+import { Card, Typography, Tag, Tabs, Layout } from 'antd';
+const { Content } = Layout;
+import { Navbar } from '../../components';
 import {
   LineChart,
   Line,
@@ -148,9 +150,12 @@ const ContributorInsights = ({ user }) => {
   ];
 
   return (
-    <div className="page-container">
-      <Tabs defaultActiveKey="line" items={items} />
-    </div>
+    <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
+      <Content className="page-container" style={{ padding: '2rem' }}>
+        <Tabs defaultActiveKey="line" items={items} />
+      </Content>
+    </Layout>
   );
 };
 

--- a/client/src/pages/contributor/Insights.js
+++ b/client/src/pages/contributor/Insights.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Typography, Tag, Tabs, Layout } from 'antd';
-const { Content } = Layout;
 import { Navbar } from '../../components';
 import {
   LineChart,
@@ -19,6 +18,7 @@ import { getContributorPayments } from '../../api/contributor/payments';
 import { getContributorAnalytics } from '../../api/contributor/profile';
 import formatDate from '../../utils/formatDate';
 import { PaymentHistoryTable } from '../../components';
+const { Content } = Layout;
 
 const { Title } = Typography;
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#d0ed57'];

--- a/client/src/pages/organization/Insights.js
+++ b/client/src/pages/organization/Insights.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Typography, Tag, Tabs, Layout } from 'antd';
 import { Navbar } from '../../components';
-const { Content } = Layout;
 import {
   LineChart,
   Line,
@@ -19,6 +18,7 @@ import { getOrganizationPayments } from '../../api/organization/payments';
 import { getOrganizationAnalytics } from '../../api/organization/profile';
 import formatDate from '../../utils/formatDate';
 import { PaymentHistoryTable } from '../../components';
+const { Content } = Layout;
 
 const { Title } = Typography;
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#d0ed57'];

--- a/client/src/pages/organization/Insights.js
+++ b/client/src/pages/organization/Insights.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Typography, Tag, Tabs } from 'antd';
+import { Card, Typography, Tag, Tabs, Layout } from 'antd';
+import { Navbar } from '../../components';
+const { Content } = Layout;
 import {
   LineChart,
   Line,
@@ -148,9 +150,12 @@ const OrganizationInsights = ({ user }) => {
   ];
 
   return (
-    <div className="page-container">
-      <Tabs defaultActiveKey="line" items={items} />
-    </div>
+    <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
+      <Content className="page-container" style={{ padding: '2rem' }}>
+        <Tabs defaultActiveKey="line" items={items} />
+      </Content>
+    </Layout>
   );
 };
 

--- a/client/src/pages/organization/Insights.js
+++ b/client/src/pages/organization/Insights.js
@@ -84,13 +84,8 @@ const OrganizationInsights = ({ user }) => {
     .sort((a, b) => a.date.localeCompare(b.date));
 
   const lineChart = (
-    <Card
-      style={{ backgroundColor: '#1f1f1f' }}
-      bodyStyle={{ padding: '1rem' }}
-    >
-      <Title level={4} style={{ color: '#fff' }}>
-        Bounties Created
-      </Title>
+    <Card bodyStyle={{ padding: '1rem' }}>
+      <Title level={4}>Bounties Created</Title>
       <ResponsiveContainer width="100%" height={300}>
         <LineChart
           data={monthlyData}
@@ -107,13 +102,8 @@ const OrganizationInsights = ({ user }) => {
   );
 
   const pieChart = (
-    <Card
-      style={{ backgroundColor: '#1f1f1f' }}
-      bodyStyle={{ padding: '1rem' }}
-    >
-      <Title level={4} style={{ color: '#fff' }}>
-        Bounty Status Distribution
-      </Title>
+    <Card bodyStyle={{ padding: '1rem' }}>
+      <Title level={4}>Bounty Status Distribution</Title>
       <ResponsiveContainer width="100%" height={400}>
         <PieChart>
           <Pie

--- a/client/src/pages/organization/OrganizationDashboard.js
+++ b/client/src/pages/organization/OrganizationDashboard.js
@@ -44,9 +44,7 @@ const OrganizationDashboard = () => {
 
   return (
     <div className="page-container">
-      <Title level={3} style={{ color: '#fff' }}>
-        My Bounties
-      </Title>
+      <Title level={3}>My Bounties</Title>
       {!emailVerified && <EmailVerificationBanner email={user.email} />}
       <Button
         icon={<PlusOutlined />}

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -8,7 +8,9 @@ import {
   Form,
   Space,
   Tag,
+  Menu,
 } from 'antd';
+import { UserOutlined, ApiOutlined } from '@ant-design/icons';
 import { motion } from 'framer-motion';
 import { Navbar } from '../../components';
 import {
@@ -23,13 +25,14 @@ import toast from '../../utils/toast';
 import { useAuth } from '../../context/AuthContext';
 import useEmailVerification from '../../hooks/useEmailVerification';
 
-const { Content } = Layout;
+const { Content, Sider } = Layout;
 const { Title, Text } = Typography;
 
 const OrganizationProfile = () => {
   const [loading, setLoading] = useState(true);
   const [form] = Form.useForm();
   const [profile, setProfile] = useState({});
+  const [section, setSection] = useState('info');
   const { user } = useAuth();
   const email = user.email || '';
   const uid = user.uid;
@@ -87,121 +90,151 @@ const OrganizationProfile = () => {
   return (
     <Layout style={{ minHeight: '100vh' }}>
       <Navbar />
-      <Content
-        className="page-container"
-        style={{ padding: '2rem', maxWidth: 800, margin: '0 auto' }}
-      >
-        <Title level={3} style={{ textAlign: 'center', marginBottom: '1rem' }}>
-          Organization Profile
-        </Title>
-        <Form form={form} layout="vertical" onFinish={handleSubmit}>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
+      <Layout>
+        <Sider breakpoint="lg" collapsedWidth="0" width={220}>
+          <Menu
+            mode="inline"
+            selectedKeys={[section]}
+            onClick={(e) => setSection(e.key)}
+            items={[
+              { key: 'info', icon: <UserOutlined />, label: 'Profile Info' },
+              {
+                key: 'integrations',
+                icon: <ApiOutlined />,
+                label: 'Integrations',
+              },
+            ]}
+          />
+        </Sider>
+        <Content
+          className="page-container"
+          style={{ padding: '2rem', maxWidth: 800, margin: '0 auto' }}
+        >
+          <Title
+            level={3}
+            style={{ textAlign: 'center', marginBottom: '1rem' }}
           >
-            <Card
-              className="section-card"
-              title="Organization Info"
-              loading={loading}
+            Organization Profile
+          </Title>
+          <Form form={form} layout="vertical" onFinish={handleSubmit}>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              hidden={section !== 'info'}
             >
-              <Form.Item
-                name="companyName"
-                label="Company Name"
-                rules={[
-                  { required: true, message: 'Please enter your company name' },
-                ]}
+              <Card
+                className="section-card"
+                title="Organization Info"
+                loading={loading}
               >
-                <Input placeholder="Example Inc." />
-              </Form.Item>
-              <Form.Item name="email" label="Email">
-                <Input value={email} disabled />
-              </Form.Item>
-              {!emailVerified ? (
-                <>
-                  <Space style={{ marginBottom: 10 }}>
-                    <Tag color="red">Email not verified</Tag>
-                    <Button size="small" onClick={handleSendVerification}>
-                      Send Verification OTP
-                    </Button>
-                  </Space>
-                  {otpSent && (
-                    <Space direction="vertical" style={{ width: '100%' }}>
-                      <Input
-                        placeholder="Enter OTP"
-                        value={token}
-                        onChange={(e) => setToken(e.target.value)}
-                      />
-                      <Button block type="primary" onClick={handleVerifyToken}>
-                        Verify Email
+                <Form.Item
+                  name="companyName"
+                  label="Company Name"
+                  rules={[
+                    {
+                      required: true,
+                      message: 'Please enter your company name',
+                    },
+                  ]}
+                >
+                  <Input placeholder="Example Inc." />
+                </Form.Item>
+                <Form.Item name="email" label="Email">
+                  <Input value={email} disabled />
+                </Form.Item>
+                {!emailVerified ? (
+                  <>
+                    <Space style={{ marginBottom: 10 }}>
+                      <Tag color="red">Email not verified</Tag>
+                      <Button size="small" onClick={handleSendVerification}>
+                        Send Verification OTP
                       </Button>
                     </Space>
-                  )}
-                </>
-              ) : (
-                <Tag color="green" style={{ marginBottom: 10 }}>
-                  Email Verified
-                </Tag>
-              )}
-              <Form.Item
-                name="description"
-                label={<Text>Company Description</Text>}
+                    {otpSent && (
+                      <Space direction="vertical" style={{ width: '100%' }}>
+                        <Input
+                          placeholder="Enter OTP"
+                          value={token}
+                          onChange={(e) => setToken(e.target.value)}
+                        />
+                        <Button
+                          block
+                          type="primary"
+                          onClick={handleVerifyToken}
+                        >
+                          Verify Email
+                        </Button>
+                      </Space>
+                    )}
+                  </>
+                ) : (
+                  <Tag color="green" style={{ marginBottom: 10 }}>
+                    Email Verified
+                  </Tag>
+                )}
+                <Form.Item
+                  name="description"
+                  label={<Text>Company Description</Text>}
+                >
+                  <Input.TextArea
+                    rows={4}
+                    placeholder="Tell us about your organization..."
+                  />
+                </Form.Item>
+                <Form.Item name="industry" label="Industry">
+                  <Input placeholder="Tech / Finance / Healthcare etc." />
+                </Form.Item>
+                <Form.Item name="website" label="Website URL">
+                  <Input placeholder="https://yourcompany.com" />
+                </Form.Item>
+              </Card>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.1 }}
+              hidden={section !== 'integrations'}
+            >
+              <Card
+                className="section-card"
+                title="GitHub Integration"
+                loading={loading}
               >
-                <Input.TextArea
-                  rows={4}
-                  placeholder="Tell us about your organization..."
+                <GitHubIntegration
+                  uid={uid}
+                  profile={profile}
+                  setProfile={setProfile}
                 />
-              </Form.Item>
-              <Form.Item name="industry" label="Industry">
-                <Input placeholder="Tech / Finance / Healthcare etc." />
-              </Form.Item>
-              <Form.Item name="website" label="Website URL">
-                <Input placeholder="https://yourcompany.com" />
-              </Form.Item>
-            </Card>
-          </motion.div>
+              </Card>
+            </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, delay: 0.1 }}
-          >
-            <Card
-              className="section-card"
-              title="GitHub Integration"
-              loading={loading}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.2 }}
+              hidden={section !== 'integrations'}
             >
-              <GitHubIntegration
-                uid={uid}
-                profile={profile}
-                setProfile={setProfile}
-              />
-            </Card>
-          </motion.div>
+              <Card
+                className="section-card"
+                title="Discord Integration"
+                loading={loading}
+              >
+                <DiscordIntegration
+                  uid={uid}
+                  profile={profile}
+                  setProfile={setProfile}
+                />
+              </Card>
+            </motion.div>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3, delay: 0.2 }}
-          >
-            <Card
-              className="section-card"
-              title="Discord Integration"
-              loading={loading}
-            >
-              <DiscordIntegration
-                uid={uid}
-                profile={profile}
-                setProfile={setProfile}
-              />
-            </Card>
-          </motion.div>
-
-          <Button type="primary" htmlType="submit" block>
-            Save
-          </Button>
-        </Form>
-      </Content>
+            <Button type="primary" htmlType="submit" block>
+              Save
+            </Button>
+          </Form>
+        </Content>
+      </Layout>
     </Layout>
   );
 };

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -83,7 +83,7 @@ const OrganizationProfile = () => {
   }, []);
 
   return (
-    <Layout style={{ minHeight: '100vh', backgroundColor: '#141414' }}>
+    <Layout style={{ minHeight: '100vh' }}>
       <Content
         className="page-container"
         style={{
@@ -95,11 +95,11 @@ const OrganizationProfile = () => {
       >
         <Card
           className="form-card"
-          style={{ backgroundColor: '#1f1f1f', marginBottom: 20 }}
+          style={{ marginBottom: 20 }}
           loading={loading}
           bodyStyle={{ padding: '1rem' }}
         >
-          <Title level={3} style={{ color: '#fff', textAlign: 'center' }}>
+          <Title level={3} style={{ textAlign: 'center' }}>
             Organization Profile
           </Title>
           <Form form={form} layout="vertical" onFinish={handleSubmit}>
@@ -113,7 +113,7 @@ const OrganizationProfile = () => {
               <Input placeholder="Example Inc." />
             </Form.Item>
             <Form.Item name="email" label="Email">
-              <Input value={email} disabled style={{ color: '#ccc' }} />
+              <Input value={email} disabled />
             </Form.Item>
             {!emailVerified ? (
               <>
@@ -143,7 +143,7 @@ const OrganizationProfile = () => {
             )}
             <Form.Item
               name="description"
-              label={<Text style={{ color: '#ddd' }}>Company Description</Text>}
+              label={<Text>Company Description</Text>}
             >
               <Input.TextArea
                 rows={4}
@@ -161,10 +161,7 @@ const OrganizationProfile = () => {
             </Button>
           </Form>
         </Card>
-        <Card
-          style={{ width: 500, backgroundColor: '#1f1f1f', marginBottom: 20 }}
-          loading={loading}
-        >
+        <Card style={{ width: 500, marginBottom: 20 }} loading={loading}>
           <GitHubIntegration
             uid={uid}
             profile={profile}
@@ -173,7 +170,6 @@ const OrganizationProfile = () => {
         </Card>
         <Card
           className="form-card"
-          style={{ backgroundColor: '#1f1f1f' }}
           loading={loading}
           bodyStyle={{ padding: '1rem' }}
         >

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -9,6 +9,7 @@ import {
   Space,
   Tag,
 } from 'antd';
+import { motion } from 'framer-motion';
 import { Navbar } from '../../components';
 import {
   getOrganizationProfile,
@@ -90,92 +91,116 @@ const OrganizationProfile = () => {
         className="page-container"
         style={{ padding: '2rem', maxWidth: 800, margin: '0 auto' }}
       >
-        <Card
-          className="form-card"
-          style={{ marginBottom: 20 }}
-          loading={loading}
-          bodyStyle={{ padding: '1rem' }}
-        >
-          <Title level={3} style={{ textAlign: 'center' }}>
-            Organization Profile
-          </Title>
-          <Form form={form} layout="vertical" onFinish={handleSubmit}>
-            <Form.Item
-              name="companyName"
-              label="Company Name"
-              rules={[
-                { required: true, message: 'Please enter your company name' },
-              ]}
+        <Title level={3} style={{ textAlign: 'center', marginBottom: '1rem' }}>
+          Organization Profile
+        </Title>
+        <Form form={form} layout="vertical" onFinish={handleSubmit}>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Card
+              className="section-card"
+              title="Organization Info"
+              loading={loading}
             >
-              <Input placeholder="Example Inc." />
-            </Form.Item>
-            <Form.Item name="email" label="Email">
-              <Input value={email} disabled />
-            </Form.Item>
-            {!emailVerified ? (
-              <>
-                <Space style={{ marginBottom: 10 }}>
-                  <Tag color="red">Email not verified</Tag>
-                  <Button size="small" onClick={handleSendVerification}>
-                    Send Verification OTP
-                  </Button>
-                </Space>
-                {otpSent && (
-                  <Space direction="vertical" style={{ width: '100%' }}>
-                    <Input
-                      placeholder="Enter OTP"
-                      value={token}
-                      onChange={(e) => setToken(e.target.value)}
-                    />
-                    <Button block type="primary" onClick={handleVerifyToken}>
-                      Verify Email
+              <Form.Item
+                name="companyName"
+                label="Company Name"
+                rules={[
+                  { required: true, message: 'Please enter your company name' },
+                ]}
+              >
+                <Input placeholder="Example Inc." />
+              </Form.Item>
+              <Form.Item name="email" label="Email">
+                <Input value={email} disabled />
+              </Form.Item>
+              {!emailVerified ? (
+                <>
+                  <Space style={{ marginBottom: 10 }}>
+                    <Tag color="red">Email not verified</Tag>
+                    <Button size="small" onClick={handleSendVerification}>
+                      Send Verification OTP
                     </Button>
                   </Space>
-                )}
-              </>
-            ) : (
-              <Tag color="green" style={{ marginBottom: 10 }}>
-                Email Verified
-              </Tag>
-            )}
-            <Form.Item
-              name="description"
-              label={<Text>Company Description</Text>}
+                  {otpSent && (
+                    <Space direction="vertical" style={{ width: '100%' }}>
+                      <Input
+                        placeholder="Enter OTP"
+                        value={token}
+                        onChange={(e) => setToken(e.target.value)}
+                      />
+                      <Button block type="primary" onClick={handleVerifyToken}>
+                        Verify Email
+                      </Button>
+                    </Space>
+                  )}
+                </>
+              ) : (
+                <Tag color="green" style={{ marginBottom: 10 }}>
+                  Email Verified
+                </Tag>
+              )}
+              <Form.Item
+                name="description"
+                label={<Text>Company Description</Text>}
+              >
+                <Input.TextArea
+                  rows={4}
+                  placeholder="Tell us about your organization..."
+                />
+              </Form.Item>
+              <Form.Item name="industry" label="Industry">
+                <Input placeholder="Tech / Finance / Healthcare etc." />
+              </Form.Item>
+              <Form.Item name="website" label="Website URL">
+                <Input placeholder="https://yourcompany.com" />
+              </Form.Item>
+            </Card>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+          >
+            <Card
+              className="section-card"
+              title="GitHub Integration"
+              loading={loading}
             >
-              <Input.TextArea
-                rows={4}
-                placeholder="Tell us about your organization..."
+              <GitHubIntegration
+                uid={uid}
+                profile={profile}
+                setProfile={setProfile}
               />
-            </Form.Item>
-            <Form.Item name="industry" label="Industry">
-              <Input placeholder="Tech / Finance / Healthcare etc." />
-            </Form.Item>
-            <Form.Item name="website" label="Website URL">
-              <Input placeholder="https://yourcompany.com" />
-            </Form.Item>
-            <Button type="primary" htmlType="submit" block>
-              Save
-            </Button>
-          </Form>
-        </Card>
-        <Card style={{ width: 500, marginBottom: 20 }} loading={loading}>
-          <GitHubIntegration
-            uid={uid}
-            profile={profile}
-            setProfile={setProfile}
-          />
-        </Card>
-        <Card
-          className="form-card"
-          loading={loading}
-          bodyStyle={{ padding: '1rem' }}
-        >
-          <DiscordIntegration
-            uid={uid}
-            profile={profile}
-            setProfile={setProfile}
-          />
-        </Card>
+            </Card>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.2 }}
+          >
+            <Card
+              className="section-card"
+              title="Discord Integration"
+              loading={loading}
+            >
+              <DiscordIntegration
+                uid={uid}
+                profile={profile}
+                setProfile={setProfile}
+              />
+            </Card>
+          </motion.div>
+
+          <Button type="primary" htmlType="submit" block>
+            Save
+          </Button>
+        </Form>
       </Content>
     </Layout>
   );

--- a/client/src/pages/organization/OrganizationProfile.js
+++ b/client/src/pages/organization/OrganizationProfile.js
@@ -9,6 +9,7 @@ import {
   Space,
   Tag,
 } from 'antd';
+import { Navbar } from '../../components';
 import {
   getOrganizationProfile,
   saveOrganizationProfile,
@@ -84,14 +85,10 @@ const OrganizationProfile = () => {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
+      <Navbar />
       <Content
         className="page-container"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          flexDirection: 'column',
-        }}
+        style={{ padding: '2rem', maxWidth: 800, margin: '0 auto' }}
       >
         <Card
           className="form-card"


### PR DESCRIPTION
## Summary
- implement theme context with dark/light mode
- switch global font to Inter and update Ant Design theme
- add theme toggle to navbar
- clean inline styling for modern look
- update login, signup, profile, and dashboard pages for theme compatibility

## Testing
- `npm --prefix client run format`
- `npm --prefix client run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449bc40c188326ada993ee39ed495a