### PR TITLE
Fix profile cache invalidation

### DIFF
--- a/server/services/integrations/DiscordService.js
+++ b/server/services/integrations/DiscordService.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const FirestoreService = require('@services/database/FirestoreService');
 const crypto = require('crypto');
+const CacheService = require('@services/misc/CacheService');
 
 const CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
@@ -50,10 +51,11 @@ class DiscordService {
   }
 
   async saveAccessTokenToOrganization(uid, accessToken) {
-    return FirestoreService.updateDocument('organizations', uid, {
+    await FirestoreService.updateDocument('organizations', uid, {
       discordAccessToken: accessToken,
       discordEnabled: true,
     });
+    await CacheService.del(`GET:/api/organization/profile/${uid}`);
   }
 
   async fetchMutualGuildChannels(uid) {
@@ -109,9 +111,10 @@ class DiscordService {
   }
 
   async saveDiscordChannel(uid, channelId) {
-    return FirestoreService.updateDocument('organizations', uid, {
+    await FirestoreService.updateDocument('organizations', uid, {
       discordChannel: channelId,
     });
+    await CacheService.del(`GET:/api/organization/profile/${uid}`);
   }
 }
 

--- a/server/services/integrations/GithubService.js
+++ b/server/services/integrations/GithubService.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const FirestoreService = require('@services/database/FirestoreService');
 const crypto = require('crypto');
+const CacheService = require('@services/misc/CacheService');
 
 const CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
@@ -63,6 +64,7 @@ class GithubService {
     await FirestoreService.updateDocument('organizations', uid, {
       githubToken: accessToken,
     });
+    await CacheService.del(`GET:/api/organization/profile/${uid}`);
   }
 
   async listRepos(uid) {
@@ -105,6 +107,7 @@ class GithubService {
     await FirestoreService.updateDocument('organizations', uid, {
       repo: repoName,
     });
+    await CacheService.del(`GET:/api/organization/profile/${uid}`);
   }
 
   async fetchOpenIssues(repo, token) {


### PR DESCRIPTION
## Summary
- ensure profile cache clears when updating GitHub or Discord integrations

## Testing
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_684c6d1f0e40832683c576937d18e417