### PR TITLE
Implement CSRF middleware and wallet portfolio

### DIFF
--- a/client/src/api/wallet.js
+++ b/client/src/api/wallet.js
@@ -23,3 +23,13 @@ export const sendFunds = async (toAddress, amount) => {
   const data = await res.json();
   return data.txHash;
 };
+
+export const getPortfolio = async () => {
+  const res = await fetchWithAuth(`${API_URL}/wallet/portfolio`);
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.message || 'Failed to fetch portfolio');
+  }
+  const data = await res.json();
+  return data.assets;
+};

--- a/client/src/pages/Wallet.js
+++ b/client/src/pages/Wallet.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Typography, Input, Button, Space } from 'antd';
+import { Card, Typography, Input, Button, Space, Table } from 'antd';
 import { useAuth } from '../context/AuthContext';
-import { getBalance, sendFunds } from '../api/wallet';
+import { getBalance, sendFunds, getPortfolio } from '../api/wallet';
 import toast from '../utils/toast';
 import AppLayout from '../components/AppLayout';
 
@@ -10,6 +10,7 @@ const { Title } = Typography;
 const Wallet = () => {
   const { user } = useAuth();
   const [balance, setBalance] = useState(0);
+  const [assets, setAssets] = useState([]);
   const [toAddress, setToAddress] = useState('');
   const [amount, setAmount] = useState('');
 
@@ -17,6 +18,8 @@ const Wallet = () => {
     try {
       const b = await getBalance();
       setBalance(b);
+      const p = await getPortfolio();
+      setAssets(p);
     } catch (err) {
       toast.error('Failed to load balance');
     }
@@ -58,6 +61,18 @@ const Wallet = () => {
         <p>
           <strong>Balance:</strong> {balance} SOL
         </p>
+      </Card>
+      <Card className="card-theme" style={{ marginBottom: 20, width: '100%' }}>
+        <Title level={4}>Portfolio</Title>
+        <Table
+          pagination={false}
+          dataSource={assets}
+          rowKey="mint"
+          columns={[
+            { title: 'Token', dataIndex: 'mint', key: 'mint' },
+            { title: 'Amount', dataIndex: 'amount', key: 'amount' },
+          ]}
+        />
       </Card>
       <Card className="form-card card-theme" bodyStyle={{ padding: '1rem' }}>
         <Title level={4}>Send Funds</Title>

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -51,6 +51,12 @@ class AuthController {
     await UserService.resetPassword(email, token, newPassword);
     return ResponseHelper.success(res, 'Password reset successful');
   }
+
+  async getCsrfToken(req, res) {
+    return ResponseHelper.success(res, 'CSRF token issued', {
+      token: process.env.CSRF_SECRET,
+    });
+  }
 }
 
 module.exports = new AuthController();

--- a/server/controllers/walletController.js
+++ b/server/controllers/walletController.js
@@ -14,6 +14,12 @@ class WalletController {
     const txHash = await WalletService.send(uid, toAddress, Number(amount));
     return ResponseHelper.success(res, 'Transaction sent', { txHash });
   }
+
+  async getPortfolio(req, res) {
+    const { uid } = req.user;
+    const assets = await WalletService.getPortfolio(uid);
+    return ResponseHelper.success(res, 'Portfolio fetched', { assets });
+  }
 }
 
 module.exports = new WalletController();

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+process.env.CSRF_SECRET = process.env.CSRF_SECRET || 'default_csrf_secret';
 require('module-alias/register');
 const express = require('express');
 const http = require('http');

--- a/server/middlewares/implementations/security/CorsMiddleware.js
+++ b/server/middlewares/implementations/security/CorsMiddleware.js
@@ -9,7 +9,7 @@ class CorsMiddleware extends IMiddleware {
       origin: process.env.FRONTEND_URL,
       credentials: true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'Authorization'],
+      allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],
     });
   }
 

--- a/server/middlewares/implementations/security/CsrfMiddleware.js
+++ b/server/middlewares/implementations/security/CsrfMiddleware.js
@@ -1,0 +1,19 @@
+const IMiddleware = require('@middlewares/IMiddleware');
+const ResponseHelper = require('@utils/ResponseHelper');
+
+class CsrfMiddleware extends IMiddleware {
+  apply(app) {
+    app.use((req, res, next) => {
+      if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) {
+        return next();
+      }
+      const token = req.headers['x-csrf-token'];
+      if (!token || token !== process.env.CSRF_SECRET) {
+        return ResponseHelper.forbidden(res, 'Invalid CSRF token');
+      }
+      return next();
+    });
+  }
+}
+
+module.exports = CsrfMiddleware;

--- a/server/routes/implementations/AuthRoutes.js
+++ b/server/routes/implementations/AuthRoutes.js
@@ -41,6 +41,8 @@ class AuthRoutes extends IRoute {
       catchAsync(AuthController.verifyOTPToken)
     );
 
+    router.get('/csrf-token', catchAsync(AuthController.getCsrfToken));
+
     app.use('/api/auth', router);
   }
 }

--- a/server/routes/implementations/WalletRoutes.js
+++ b/server/routes/implementations/WalletRoutes.js
@@ -14,6 +14,8 @@ class WalletRoutes extends IRoute {
 
     router.get('/balance', catchAsync(WalletController.getBalance));
 
+    router.get('/portfolio', catchAsync(WalletController.getPortfolio));
+
     router.post(
       '/send',
       ValidationMiddleware.use(walletValidator.sendSchema),

--- a/server/services/misc/EncryptionService.js
+++ b/server/services/misc/EncryptionService.js
@@ -23,6 +23,7 @@ class EncryptionService {
 
   static decrypt(encryptedText) {
     try {
+      if (!encryptedText.includes(':')) return null;
       const [ivHex, encrypted] = encryptedText.split(':');
       const iv = Buffer.from(ivHex, 'hex');
       const decipher = crypto.createDecipheriv(

--- a/server/services/user/ContributorService.js
+++ b/server/services/user/ContributorService.js
@@ -35,6 +35,7 @@ class ContributorService {
       submittedLink,
     });
 
+    await CacheService.del('GET:*bounties*');
     await CacheService.del('GET:*payments*');
 
     await EmailService.sendSubmissionNotificationToOrganization({


### PR DESCRIPTION
## Summary
- add CSRF middleware and expose CSRF token via auth route
- allow CORS header for CSRF token
- invalidate bounty cache on submit
- provide wallet portfolio endpoint and UI
- handle invalid ciphertexts in encryption service

## Testing
- `npm run format:check` in `server`
- `npm run format:check` in `client`


------
https://chatgpt.com/codex/tasks/task_e_684d998b0ca48326b8638dd3aac3bad3