### PR TITLE
Add future deadline check and truncate bounty cards

### DIFF
--- a/client/src/components/contributor/BountyCard.js
+++ b/client/src/components/contributor/BountyCard.js
@@ -26,6 +26,7 @@ const BountyCard = ({
 }) => {
   const { user } = useAuth();
   const emailVerified = user?.emailVerified || false;
+  const [expanded, setExpanded] = React.useState(false);
   const handleApplyToBounty = async () => {
     if (!emailVerified) {
       toast.warning('Please verify your email before applying');
@@ -91,7 +92,17 @@ const BountyCard = ({
           </p>
         )}
 
-        <p>{truncateWords(bounty.description)}</p>
+        <p>
+          {expanded ? bounty.description : truncateWords(bounty.description)}
+          {truncateWords(bounty.description) !== bounty.description && (
+            <span
+              onClick={() => setExpanded(!expanded)}
+              style={{ color: '#1890ff', cursor: 'pointer', marginLeft: 4 }}
+            >
+              {expanded ? 'See Less' : 'See More'}
+            </span>
+          )}
+        </p>
 
         {Array.isArray(bounty.tags) && bounty.tags.length > 0 && (
           <div style={{ margin: '8px 0' }}>

--- a/client/src/components/contributor/BountyCard.js
+++ b/client/src/components/contributor/BountyCard.js
@@ -4,6 +4,7 @@ import { Card, Typography, Tag, Button, Col } from 'antd';
 import { applyToBounty, unassignSelf } from '../../api/contributor/bounties';
 import toast from '../../utils/toast';
 import formatDateBounty from '../../utils/formatDateBounty';
+import truncateWords from '../../utils/truncateWords';
 import { useAuth } from '../../context/AuthContext';
 
 const { Text } = Typography;
@@ -90,7 +91,7 @@ const BountyCard = ({
           </p>
         )}
 
-        <p>{bounty.description}</p>
+        <p>{truncateWords(bounty.description)}</p>
 
         {Array.isArray(bounty.tags) && bounty.tags.length > 0 && (
           <div style={{ margin: '8px 0' }}>

--- a/client/src/components/organization/BountyCard.js
+++ b/client/src/components/organization/BountyCard.js
@@ -18,6 +18,7 @@ const statusColors = {
 };
 
 const BountyCard = ({ bounty, onView, onChatOpen, onRefetch }) => {
+  const [expanded, setExpanded] = React.useState(false);
   const handleDelete = async (e) => {
     e.stopPropagation();
     try {
@@ -65,7 +66,20 @@ const BountyCard = ({ bounty, onView, onChatOpen, onRefetch }) => {
             </a>
           </p>
         )}
-        <p>{truncateWords(bounty.description)}</p>
+        <p>
+          {expanded ? bounty.description : truncateWords(bounty.description)}
+          {truncateWords(bounty.description) !== bounty.description && (
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                setExpanded(!expanded);
+              }}
+              style={{ color: '#1890ff', cursor: 'pointer', marginLeft: 4 }}
+            >
+              {expanded ? 'See Less' : 'See More'}
+            </span>
+          )}
+        </p>
         <Button key="delete" danger onClick={handleDelete}>
           Delete
         </Button>{' '}

--- a/client/src/components/organization/BountyCard.js
+++ b/client/src/components/organization/BountyCard.js
@@ -4,6 +4,7 @@ import { Card, Typography, Tag, Button, Col } from 'antd';
 import { MessageOutlined } from '@ant-design/icons';
 import { deleteBounty } from '../../api/organization/bounties';
 import formatDateBounty from '../../utils/formatDateBounty';
+import truncateWords from '../../utils/truncateWords';
 import toast from '../../utils/toast';
 
 const { Text } = Typography;
@@ -64,7 +65,7 @@ const BountyCard = ({ bounty, onView, onChatOpen, onRefetch }) => {
             </a>
           </p>
         )}
-        <p>{bounty.description}</p>
+        <p>{truncateWords(bounty.description)}</p>
         <Button key="delete" danger onClick={handleDelete}>
           Delete
         </Button>{' '}

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Modal, Form, Input, DatePicker, Button, Tooltip, Grid } from 'antd';
+import dayjs from 'dayjs';
 import { createBounty } from '../../api/organization/bounties';
 import toast from '../../utils/toast';
 import { useAuth } from '../../context/AuthContext';
@@ -60,7 +61,12 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
           label="Deadline"
           rules={[{ required: true, message: 'Please enter Deadline' }]}
         >
-          <DatePicker style={{ width: '100%' }} />
+          <DatePicker
+            style={{ width: '100%' }}
+            disabledDate={(current) =>
+              current && current <= dayjs().endOf('day')
+            }
+          />
         </Form.Item>
         <Form.Item
           name="amount"

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -64,7 +64,7 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
           <DatePicker
             style={{ width: '100%' }}
             disabledDate={(current) =>
-              current && current < dayjs().startOf('day')
+              current && current <= dayjs().startOf('day')
             }
           />
         </Form.Item>

--- a/client/src/components/organization/CreateBountyModal.js
+++ b/client/src/components/organization/CreateBountyModal.js
@@ -64,7 +64,7 @@ const CreateBountyModal = ({ visible, onCancel, onCreateSuccess, userId }) => {
           <DatePicker
             style={{ width: '100%' }}
             disabledDate={(current) =>
-              current && current <= dayjs().endOf('day')
+              current && current < dayjs().startOf('day')
             }
           />
         </Form.Item>

--- a/client/src/components/organization/ViewBountyModal.js
+++ b/client/src/components/organization/ViewBountyModal.js
@@ -106,6 +106,9 @@ const ViewBountyModal = ({
           <DatePicker
             style={{ width: '100%' }}
             placeholder="Deadline"
+            disabledDate={(current) =>
+              current && current < dayjs().startOf('day')
+            }
             value={
               bounty.deadline
                 ? dayjs(

--- a/client/src/components/organization/ViewBountyModal.js
+++ b/client/src/components/organization/ViewBountyModal.js
@@ -107,7 +107,7 @@ const ViewBountyModal = ({
             style={{ width: '100%' }}
             placeholder="Deadline"
             disabledDate={(current) =>
-              current && current < dayjs().startOf('day')
+              current && current <= dayjs().startOf('day')
             }
             value={
               bounty.deadline

--- a/client/src/utils/truncateWords.js
+++ b/client/src/utils/truncateWords.js
@@ -1,0 +1,8 @@
+function truncateWords(text, limit = 40) {
+  if (!text) return '';
+  const words = text.trim().split(/\s+/);
+  if (words.length <= limit) return text;
+  return words.slice(0, limit).join(' ') + '... see more';
+}
+
+export default truncateWords;

--- a/client/src/utils/truncateWords.js
+++ b/client/src/utils/truncateWords.js
@@ -1,8 +1,8 @@
-function truncateWords(text, limit = 40) {
+function truncateWords(text, limit = 30) {
   if (!text) return '';
   const words = text.trim().split(/\s+/);
   if (words.length <= limit) return text;
-  return words.slice(0, limit).join(' ') + '... see more';
+  return words.slice(0, limit).join(' ') + '...';
 }
 
 export default truncateWords;

--- a/server/services/user/OrganizationService.js
+++ b/server/services/user/OrganizationService.js
@@ -10,7 +10,7 @@ class OrganizationService {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const deadlineDate = new Date(values.deadline);
-    if (deadlineDate < today) {
+    if (deadlineDate <= today) {
       const err = new Error('Deadline cannot be in the past');
       err.status = 400;
       throw err;
@@ -46,7 +46,7 @@ class OrganizationService {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
       const deadlineDate = new Date(updateData.deadline);
-      if (deadlineDate < today) {
+      if (deadlineDate <= today) {
         const err = new Error('Deadline cannot be in the past');
         err.status = 400;
         throw err;

--- a/server/services/user/OrganizationService.js
+++ b/server/services/user/OrganizationService.js
@@ -7,10 +7,11 @@ const PrivyService = require('@services/integrations/PrivyService');
 
 class OrganizationService {
   async createBounty(values, userId) {
-    const now = new Date();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
     const deadlineDate = new Date(values.deadline);
-    if (deadlineDate <= now) {
-      const err = new Error('Deadline must be in the future');
+    if (deadlineDate < today) {
+      const err = new Error('Deadline cannot be in the past');
       err.status = 400;
       throw err;
     }
@@ -41,6 +42,16 @@ class OrganizationService {
   }
 
   async updateBounty(bountyId, updateData) {
+    if (updateData.deadline) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const deadlineDate = new Date(updateData.deadline);
+      if (deadlineDate < today) {
+        const err = new Error('Deadline cannot be in the past');
+        err.status = 400;
+        throw err;
+      }
+    }
     const res = await FirestoreService.updateDocument(
       'bounties',
       bountyId,

--- a/server/services/user/OrganizationService.js
+++ b/server/services/user/OrganizationService.js
@@ -7,6 +7,13 @@ const PrivyService = require('@services/integrations/PrivyService');
 
 class OrganizationService {
   async createBounty(values, userId) {
+    const now = new Date();
+    const deadlineDate = new Date(values.deadline);
+    if (deadlineDate <= now) {
+      const err = new Error('Deadline must be in the future');
+      err.status = 400;
+      throw err;
+    }
     const bounty = {
       name: values.name || '',
       description: values.description || '',

--- a/server/validators/organizationValidators.js
+++ b/server/validators/organizationValidators.js
@@ -5,7 +5,7 @@ const createBountySchema = {
     values: Joi.object({
       name: Joi.string().min(3).max(100).required(),
       description: Joi.string().min(10).max(2000).required(),
-      deadline: Joi.date().required(),
+      deadline: Joi.date().greater('now').required(),
       amount: Joi.number().min(0.3).required(),
       tags: Joi.string().optional(),
     }).required(),

--- a/server/validators/organizationValidators.js
+++ b/server/validators/organizationValidators.js
@@ -5,7 +5,7 @@ const createBountySchema = {
     values: Joi.object({
       name: Joi.string().min(3).max(100).required(),
       description: Joi.string().min(10).max(2000).required(),
-      deadline: Joi.date().greater('now').required(),
+      deadline: Joi.date().required(),
       amount: Joi.number().min(0.3).required(),
       tags: Joi.string().optional(),
     }).required(),


### PR DESCRIPTION
## Summary
- enforce that bounty deadlines are set in the future on the backend
- block past or present dates in the Create Bounty form
- show shortened descriptions on bounty cards

## Testing
- `npm run format` in `client`
- `npm run format` in `server`
- `npm run format:check` in `server`
- `npm run format:check` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685fb214511c8326bb1ee11e4c90caee