### PR TITLE
Add OpenAPI spec for REST API

### DIFF
--- a/gitbook/rest-api/auth.md
+++ b/gitbook/rest-api/auth.md
@@ -1,10 +1,15 @@
 # Auth API
 
-Placeholder overview of authentication-related routes.
+Authentication related endpoints.
 
-- **POST /api/auth/login** - log a user in
-- **POST /api/auth/signup** - create a new account
-- **POST /api/auth/forgot-password** - request a password reset
-- **POST /api/auth/reset-password** - reset the password
-- **POST /api/auth/verify-email** - verify an email address
-- **POST /api/auth/verify-token** - verify a password reset token
+{% openapi src="./openapi.yaml" path="/api/auth/login" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/auth/signup" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/auth/forgot-password" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/auth/reset-password" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/auth/verify-email" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/auth/verify-token" method="post" %}{% endopenapi %}

--- a/gitbook/rest-api/contributor.md
+++ b/gitbook/rest-api/contributor.md
@@ -1,12 +1,19 @@
 # Contributor API
 
-List of routes for contributor-related operations.
+Endpoints for contributor operations.
 
-- **POST /api/contributor/apply** - apply to a bounty
-- **POST /api/contributor/submit** - submit work
-- **GET /api/contributor/get-bounties** - list available bounties
-- **GET /api/contributor/get-profile** - retrieve contributor profile
-- **POST /api/contributor/update-profile** - update contributor profile
-- **POST /api/contributor/unassign** - unassign from a bounty
-- **GET /api/contributor/payments** - list payments
-- **GET /api/contributor/analytics** - view analytics
+{% openapi src="./openapi.yaml" path="/api/contributor/apply" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/submit" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/bounties/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/profile/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/profile/{uid}" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/unassign" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/payments/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/contributor/analytics/{uid}" method="get" %}{% endopenapi %}

--- a/gitbook/rest-api/discord.md
+++ b/gitbook/rest-api/discord.md
@@ -1,8 +1,11 @@
 # Discord API
 
-Endpoints used for Discord integration.
+Integration with Discord.
 
-- **GET /api/discord/oauth** - start OAuth flow
-- **GET /api/discord/callback** - handle OAuth callback
-- **GET /api/discord/get-channels** - list channels from a guild
-- **POST /api/discord/save-channel** - save channel configuration
+{% openapi src="./openapi.yaml" path="/api/discord/oauth" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/discord/callback" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/discord/channels/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/discord/channel/{uid}" method="put" %}{% endopenapi %}

--- a/gitbook/rest-api/github.md
+++ b/gitbook/rest-api/github.md
@@ -1,8 +1,11 @@
 # GitHub API
 
-Routes for GitHub repository management and authentication.
+Endpoints for GitHub integration.
 
-- **GET /api/github/auth** - begin OAuth process
-- **GET /api/github/callback** - handle OAuth callback
-- **GET /api/github/list-repos** - list repositories for the authenticated user
-- **POST /api/github/save-repo** - save a repository to the organization
+{% openapi src="./openapi.yaml" path="/api/github/auth" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/github/callback" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/github/repos/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/github/repo/{uid}" method="post" %}{% endopenapi %}

--- a/gitbook/rest-api/openapi.yaml
+++ b/gitbook/rest-api/openapi.yaml
@@ -1,0 +1,818 @@
+openapi: 3.0.0
+info:
+  title: The DAO Tool API
+  version: "1.0.0"
+  description: |
+    REST API for managing bounties, contributors and organizations along with
+    GitHub and Discord integrations.
+servers:
+  - url: https://api.example.com
+  - url: http://localhost:3000
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /api/auth/login:
+    post:
+      summary: User login
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  minLength: 8
+              required:
+                - email
+                - password
+      responses:
+        '200':
+          description: Login successful
+        '401':
+          description: Invalid credentials
+      tags:
+        - Auth
+  /api/auth/signup:
+    post:
+      summary: Create new account
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  minLength: 8
+                role:
+                  type: string
+                  enum: [contributor, organization]
+              required:
+                - email
+                - password
+                - role
+      responses:
+        '200':
+          description: Signup successful
+      tags:
+        - Auth
+  /api/auth/forgot-password:
+    post:
+      summary: Request password reset link
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+              required:
+                - email
+      responses:
+        '200':
+          description: Reset email sent
+      tags:
+        - Auth
+  /api/auth/reset-password:
+    post:
+      summary: Reset user password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                token:
+                  type: string
+                newPassword:
+                  type: string
+                  minLength: 8
+              required:
+                - email
+                - token
+                - newPassword
+      responses:
+        '200':
+          description: Password reset
+      tags:
+        - Auth
+  /api/auth/verify-email:
+    post:
+      summary: Send verification email
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+              required:
+                - email
+      responses:
+        '200':
+          description: Verification sent
+      tags:
+        - Auth
+  /api/auth/verify-token:
+    post:
+      summary: Verify OTP or reset token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                token:
+                  type: string
+              required:
+                - email
+                - token
+      responses:
+        '200':
+          description: Token verified
+      tags:
+        - Auth
+  /api/contributor/apply:
+    post:
+      summary: Apply to a bounty
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bountyId:
+                  type: string
+              required:
+                - bountyId
+      responses:
+        '200':
+          description: Application submitted
+      tags:
+        - Contributor
+  /api/contributor/submit:
+    post:
+      summary: Submit work for a bounty
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bountyId:
+                  type: string
+                submittedLink:
+                  type: string
+                  format: uri
+              required:
+                - bountyId
+                - submittedLink
+      responses:
+        '200':
+          description: Work submitted
+      tags:
+        - Contributor
+  /api/contributor/bounties/{uid}:
+    get:
+      summary: Fetch available bounties
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of bounties
+      tags:
+        - Contributor
+  /api/contributor/profile/{uid}:
+    get:
+      summary: Get contributor profile
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Contributor profile
+      tags:
+        - Contributor
+    put:
+      summary: Update contributor profile
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                linkedin:
+                  type: string
+                  format: uri
+                portfolio:
+                  type: string
+                  format: uri
+                roleTitle:
+                  type: string
+                skills:
+                  type: string
+      responses:
+        '200':
+          description: Profile updated
+      tags:
+        - Contributor
+  /api/contributor/unassign:
+    put:
+      summary: Unassign from a bounty
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bountyId:
+                  type: string
+              required:
+                - bountyId
+      responses:
+        '200':
+          description: Unassigned
+      tags:
+        - Contributor
+  /api/contributor/payments/{uid}:
+    get:
+      summary: List contributor payments
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Payment history
+      tags:
+        - Contributor
+  /api/contributor/analytics/{uid}:
+    get:
+      summary: View contributor analytics
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Analytics information
+      tags:
+        - Contributor
+  /api/discord/oauth:
+    get:
+      summary: Start Discord OAuth flow
+      parameters:
+        - in: query
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirect to Discord
+      tags:
+        - Discord
+  /api/discord/callback:
+    get:
+      summary: Discord OAuth callback
+      parameters:
+        - in: query
+          name: code
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: state
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OAuth complete
+      tags:
+        - Discord
+  /api/discord/channels/{uid}:
+    get:
+      summary: Fetch Discord channels for organization
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of channels
+      tags:
+        - Discord
+  /api/discord/channel/{uid}:
+    put:
+      summary: Save selected Discord channel
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channelId:
+                  type: string
+              required:
+                - channelId
+      responses:
+        '200':
+          description: Channel saved
+      tags:
+        - Discord
+  /api/github/auth:
+    get:
+      summary: Start GitHub OAuth flow
+      parameters:
+        - in: query
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        '302':
+          description: Redirect to GitHub
+      tags:
+        - GitHub
+  /api/github/callback:
+    get:
+      summary: GitHub OAuth callback
+      parameters:
+        - in: query
+          name: code
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: state
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OAuth complete
+      tags:
+        - GitHub
+  /api/github/repos/{uid}:
+    get:
+      summary: List repositories for organization
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Repository list
+      tags:
+        - GitHub
+  /api/github/repo/{uid}:
+    post:
+      summary: Save selected repository
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repo:
+                  type: string
+              required:
+                - repo
+      responses:
+        '200':
+          description: Repository saved
+      tags:
+        - GitHub
+  /api/organization/bounty:
+    post:
+      summary: Create a new bounty
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                values:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    description:
+                      type: string
+                    deadline:
+                      type: string
+                      format: date-time
+                    amount:
+                      type: number
+                    tags:
+                      type: string
+                  required:
+                    - name
+                    - description
+                    - deadline
+                    - amount
+                userId:
+                  type: string
+              required:
+                - values
+                - userId
+      responses:
+        '200':
+          description: Bounty created
+      tags:
+        - Organization
+  /api/organization/bounty/{id}:
+    delete:
+      summary: Delete a bounty
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bounty removed
+      tags:
+        - Organization
+    put:
+      summary: Update bounty details
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                deadline:
+                  type: string
+                  format: date-time
+                amount:
+                  type: number
+                status:
+                  type: string
+                  enum: [open, assigned, pending_payment, paid, closed]
+                submittedLink:
+                  type: string
+                  format: uri
+                contributorId:
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Bounty updated
+      tags:
+        - Organization
+  /api/organization/bounties/{uid}:
+    get:
+      summary: List bounties for an organization
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bounty list
+      tags:
+        - Organization
+  /api/organization/contributor/{id}:
+    get:
+      summary: Get contributor details
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Contributor details
+      tags:
+        - Organization
+    put:
+      summary: Update contributor
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                linkedin:
+                  type: string
+                  format: uri
+                portfolio:
+                  type: string
+                  format: uri
+                roleTitle:
+                  type: string
+                accountNumber:
+                  type: string
+                routingNumber:
+                  type: string
+                skills:
+                  type: string
+      responses:
+        '200':
+          description: Contributor updated
+      tags:
+        - Organization
+  /api/organization/bounties/{bountyId}/unassign:
+    put:
+      summary: Unassign a contributor from bounty
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: bountyId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Contributor unassigned
+      tags:
+        - Organization
+  /api/organization/bounties/{bountyId}/pay:
+    post:
+      summary: Pay bounty reward
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: bountyId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Payment sent
+      tags:
+        - Organization
+  /api/organization/profile/{uid}:
+    get:
+      summary: Get organization profile
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Organization profile
+      tags:
+        - Organization
+    put:
+      summary: Save organization profile
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                apiKey:
+                  type: string
+                companyName:
+                  type: string
+                description:
+                  type: string
+                discordAccessToken:
+                  type: string
+                discordChannelId:
+                  type: string
+                discordEnabled:
+                  type: boolean
+                discordGuild:
+                  type: string
+                discordSendMode:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                githubToken:
+                  type: string
+                industry:
+                  type: string
+                repo:
+                  type: string
+                website:
+                  type: string
+                  format: uri
+      responses:
+        '200':
+          description: Profile saved
+      tags:
+        - Organization
+  /api/organization/payments/{uid}:
+    get:
+      summary: View payment history
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Organization payment history
+      tags:
+        - Organization
+  /api/organization/analytics/{uid}:
+    get:
+      summary: Organization analytics
+      security:
+        - BearerAuth: []
+      parameters:
+        - in: path
+          name: uid
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Analytics information
+      tags:
+        - Organization
+  /api/wallet/balance:
+    get:
+      summary: Get wallet balance
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current balance
+      tags:
+        - Wallet
+  /api/wallet/send:
+    post:
+      summary: Send funds from wallet
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                toAddress:
+                  type: string
+                amount:
+                  type: number
+                  minimum: 0.3
+              required:
+                - toAddress
+                - amount
+      responses:
+        '200':
+          description: Transaction sent
+      tags:
+        - Wallet

--- a/gitbook/rest-api/organization.md
+++ b/gitbook/rest-api/organization.md
@@ -2,15 +2,26 @@
 
 Endpoints for managing bounties, contributors, and organization profiles.
 
-- **POST /api/organization/create-bounty** - create a new bounty
-- **DELETE /api/organization/delete-bounty** - remove a bounty
-- **PUT /api/organization/update-bounty** - update bounty details
-- **GET /api/organization/list-bounties** - list bounties for an organization
-- **GET /api/organization/get-contributor** - fetch contributor details
-- **PUT /api/organization/update-contributor** - update contributor status
-- **POST /api/organization/unassign-contributor** - unassign a contributor
-- **POST /api/organization/pay-bounty** - send bounty payment
-- **GET /api/organization/get-profile** - get organization profile
-- **POST /api/organization/save-profile** - save organization profile
-- **GET /api/organization/get-payments** - view payment history
-- **GET /api/organization/analytics** - view analytics
+{% openapi src="./openapi.yaml" path="/api/organization/bounty" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/bounty/{id}" method="delete" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/bounty/{id}" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/bounties/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/contributor/{id}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/contributor/{id}" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/bounties/{bountyId}/unassign" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/bounties/{bountyId}/pay" method="post" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/profile/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/profile/{uid}" method="put" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/payments/{uid}" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/organization/analytics/{uid}" method="get" %}{% endopenapi %}

--- a/gitbook/rest-api/overview.md
+++ b/gitbook/rest-api/overview.md
@@ -1,3 +1,3 @@
 # REST API
 
-Documentation for all backend endpoints.
+The following pages document each REST endpoint in detail. The API definitions are sourced from the OpenAPI specification located in this directory.

--- a/gitbook/rest-api/wallet.md
+++ b/gitbook/rest-api/wallet.md
@@ -1,6 +1,7 @@
 # Wallet API
 
-Endpoints for wallet interactions.
+Endpoints for wallet operations.
 
-- **GET /api/wallet/balance** - check wallet balance
-- **POST /api/wallet/send** - send funds
+{% openapi src="./openapi.yaml" path="/api/wallet/balance" method="get" %}{% endopenapi %}
+
+{% openapi src="./openapi.yaml" path="/api/wallet/send" method="post" %}{% endopenapi %}


### PR DESCRIPTION
## Summary
- document all REST endpoints in new `openapi.yaml`
- embed OpenAPI blocks in each REST API page

## Testing
- `npm --prefix server run format:check`
- `npm --prefix client run format:check`


------
https://chatgpt.com/codex/tasks/task_e_686048781b40832695cdf210b490531b