### PR TITLE
Update docs structure for local setup

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -4,8 +4,16 @@
 
 ## Getting Started
 * [Overview](getting-started/overview.md)
-* [Running with Docker](getting-started/docker.md)
-* [Local Setup](getting-started/local-setup.md)
+* [Quickstart](getting-started/quickstart.md)
+
+## Local Setup
+* [Overview](local-setup/overview.md)
+* [Running with Docker](local-setup/docker.md)
+* [GitHub](local-setup/github.md)
+* [Discord Bot](local-setup/discord-bot.md)
+* [Firebase](local-setup/firebase.md)
+* [Privy](local-setup/privy.md)
+* [Mail Setup](local-setup/mail-setup.md)
 
 ## Project Structure
 * [Overview](project-structure/overview.md)
@@ -28,11 +36,6 @@
 * [Cron Jobs](backend/cron.md)
 * [Sockets](backend/sockets.md)
 
-## Configuration
-* [Environment Variables](configuration/env.md)
-* [Docker](configuration/docker.md)
-* [Scripts](configuration/scripts.md)
-
 ## REST API
 * [Overview](rest-api/overview.md)
 * [Auth](rest-api/auth.md)
@@ -44,7 +47,6 @@
 
 ## Extras
 * [Troubleshooting](extras/troubleshooting.md)
-* [Deployment](extras/deployment.md)
 
 ## Community
 * [Contributing](community/contributing.md)

--- a/gitbook/configuration/docker.md
+++ b/gitbook/configuration/docker.md
@@ -1,3 +1,0 @@
-# Docker Configuration
-
-Explanation of Dockerfile and docker-compose usage.

--- a/gitbook/configuration/env.md
+++ b/gitbook/configuration/env.md
@@ -1,3 +1,0 @@
-# Environment Variables
-
-Guidance on configuring the `.env` file and environment settings.

--- a/gitbook/configuration/scripts.md
+++ b/gitbook/configuration/scripts.md
@@ -1,3 +1,0 @@
-# Scripts
-
-Overview of npm or shell scripts for building, starting, and testing the application.

--- a/gitbook/extras/deployment.md
+++ b/gitbook/extras/deployment.md
@@ -1,3 +1,0 @@
-# Deployment
-
-Notes and tips for deploying the application to production.

--- a/gitbook/getting-started/local-setup.md
+++ b/gitbook/getting-started/local-setup.md
@@ -1,7 +1,0 @@
----
-icon: terminal
----
-
-# Local Setup
-
-Steps for running the project locally without Docker.

--- a/gitbook/local-setup/discord-bot.md
+++ b/gitbook/local-setup/discord-bot.md
@@ -1,0 +1,3 @@
+# Discord Bot
+
+Setup instructions for the Discord bot.

--- a/gitbook/local-setup/docker.md
+++ b/gitbook/local-setup/docker.md
@@ -1,7 +1,3 @@
----
-icon: docker
----
-
 # Running with Docker
 
 Instructions for running the application using Docker containers.

--- a/gitbook/local-setup/firebase.md
+++ b/gitbook/local-setup/firebase.md
@@ -1,0 +1,3 @@
+# Firebase
+
+Instructions for configuring Firebase.

--- a/gitbook/local-setup/github.md
+++ b/gitbook/local-setup/github.md
@@ -1,0 +1,3 @@
+# GitHub
+
+Setup instructions for GitHub integration.

--- a/gitbook/local-setup/mail-setup.md
+++ b/gitbook/local-setup/mail-setup.md
@@ -1,0 +1,3 @@
+# Mail Setup
+
+Use an app password from Google to enable email features.

--- a/gitbook/local-setup/overview.md
+++ b/gitbook/local-setup/overview.md
@@ -1,0 +1,7 @@
+---
+icon: terminal
+---
+
+# Local Setup
+
+Follow these instructions to get the project running on your machine. The previous deployment guide has been merged here.

--- a/gitbook/local-setup/privy.md
+++ b/gitbook/local-setup/privy.md
@@ -1,0 +1,3 @@
+# Privy
+
+Instructions for setting up Privy wallets.


### PR DESCRIPTION
## Summary
- merge deployment details into Local Setup section
- add subtasks for GitHub, Discord bot, Firebase, Privy and mail setup
- move Docker instructions under Local Setup
- drop old configuration section

## Testing
- `npm run format:check` in `client`
- `npm run format:check` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6866bb138c448326a9dded5750d4f327